### PR TITLE
Relocate dependency packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@
  * For more details take a look at the Java Libraries chapter in the Gradle
  * User Manual available at https://docs.gradle.org/5.6.2/userguide/java_library_plugin.html
  */
+import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 
 plugins {
   id 'java'
@@ -39,3 +40,10 @@ test {
   dependsOn shadowJar
   jvmArgs "-javaagent:${shadowJar.archivePath}"
 }
+
+task relocateShadowJar(type: ConfigureShadowRelocation) {
+    target = tasks.shadowJar
+    prefix = "appmap"
+}
+
+tasks.shadowJar.dependsOn tasks.relocateShadowJar


### PR DESCRIPTION
This prevents us from introducing a dependency which contains breaking changes to a downstream project.