### PR TITLE
feat: Update output from validate command

### DIFF
--- a/src/main/java/com/appland/appmap/cli/Validate.java
+++ b/src/main/java/com/appland/appmap/cli/Validate.java
@@ -4,9 +4,12 @@ import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.serializer.SerializerFeature;
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
+import org.yaml.snakeyaml.Yaml;
 import picocli.CommandLine;
 
+import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 @CommandLine.Command(name = "validate", description = "Validates that a Java project is ready to create AppMaps.")
@@ -23,6 +26,16 @@ public class Validate implements Callable<Integer> {
     }
   }
 
+  static class ValidationResult {
+    public final Integer version = 2;
+    public ArrayList<Error> errors;
+    public Map<?, ?> schema;
+    ValidationResult(ArrayList<Error> errors, Map<?, ?>schema) {
+      this.errors = errors;
+      this.schema = schema;
+    }
+  }
+
   private Error checkVersion() {
     Error ret = null;
     if (!SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_1_8)) {
@@ -34,15 +47,23 @@ public class Validate implements Callable<Integer> {
   public Integer call() {
     System.err.printf("Validating AppMap project in directory: %s\n", parent.directory);
 
-    ArrayList<Error> result = new ArrayList<Error>();
+    ArrayList<Error> errors = new ArrayList<Error>();
 
     Error nextError;
     if ((nextError = checkVersion()) != null) {
-      result.add(nextError);
+      errors.add(nextError);
     }
 
-    parent.getOutputStream().println(JSON.toJSONString(result, SerializerFeature.PrettyFormat));
+    final ClassLoader cl = getClass().getClassLoader();
+    final InputStream schemaStream = cl.getResourceAsStream("config-schema.yml");
+    final Yaml yaml = new Yaml();
+    final Map<?, ?> schema = (Map<?, ?>)yaml.load(schemaStream);
 
-    return result.size() == 0?  0 : 1;
+    final ValidationResult result = new ValidationResult(errors, schema);
+
+    parent.getOutputStream().println(JSON.toJSONString(result, SerializerFeature.PrettyFormat).replace("\t", "  "));
+
+    // Let the CLI decide whether validation failed.
+    return 0;
   }
 }

--- a/src/main/resources/config-schema.yml
+++ b/src/main/resources/config-schema.yml
@@ -15,9 +15,14 @@ properties:
       properties:
         path:
           type: string
+          # Not too strict, but should eliminate at least some
+          # incorrect names (e.g. filesystem paths instead of
+          # packages)
+          pattern: ^[a-zA-Z0-9_.#]+$
         shallow:
           type: boolean
         exclude:
           type: array
           items:
             type: string
+            pattern: ^[a-zA-Z0-9_.#]+$

--- a/test/agent_cli/agent_cli.bats
+++ b/test/agent_cli/agent_cli.bats
@@ -12,7 +12,6 @@ appmap_jar=build/libs/$(ls build/libs | grep 'appmap-[[:digit:]]')
 @test "appmap agent init packages" {
   run bash -c "java -jar $appmap_jar -d test/agent_cli/sampleproj init 2>/dev/null"
   assert_success
-
   assert_json_contains '.configuration.contents' 'path: pkg1'
   assert_json_contains '.configuration.contents' 'path: pkg2'
 }
@@ -40,7 +39,16 @@ appmap_jar=build/libs/$(ls build/libs | grep 'appmap-[[:digit:]]')
 }
 
 @test "appmap agent validate" {
-  run bash -c "java -jar $appmap_jar -d test/agent_cli/spring-petclinic status 2>/dev/null"
+  run bash -c "java -jar $appmap_jar -d test/agent_cli/spring-petclinic validate 2>/dev/null"
   assert_success
 
+  # Shouldn't be any errors
+  assert_json '.errors | length == 0'
+
+  # Sanity check a couple of the config schema properties
+  assert_json_eq '.schema.type' 'object'
+  assert_json_eq '.schema.additionalProperties' 'false'
+  assert_json_eq '.schema.required' '[
+  "name"
+]'
 }


### PR DESCRIPTION
Include the config schema in the JSON returned from the validate
subcommand. Also changes the command's return value to match the way
appmap-agent-validate in appmap-ruby works. This makes it easier for the
appmap-js CLI to decide whether validation was successful.