### PR TITLE
Handle Spring parameterized requests correctly

### DIFF
--- a/agent/src/main/java/com/appland/appmap/process/hooks/HttpServerRequest.java
+++ b/agent/src/main/java/com/appland/appmap/process/hooks/HttpServerRequest.java
@@ -255,10 +255,9 @@ public class HttpServerRequest {
   }
 
   private static void addSpringPath(HttpServletRequest req) {
-    final String pattern = (String) req
-        .getAttribute(BEST_MATCHING_PATTERN_ATTRIBUTE);
-    if (pattern != null) {
-      final Event lastEvent = (Event) req.getAttribute(LAST_EVENT_KEY);
+    final String uri = (String)req.getRequestURI();
+    if (uri != null) {
+      final Event lastEvent = (Event)req.getAttribute(LAST_EVENT_KEY);
       if (lastEvent == null || lastEvent.httpServerRequest == null) {
         return;
       }
@@ -266,11 +265,14 @@ public class HttpServerRequest {
       // the session.
       lastEvent.defrost();
 
-      final String normalizedPath = pattern.replace('{', ':').replace("}", "");
-      lastEvent.httpServerRequest.setNormalizedPath(normalizedPath);
-
       Map<String, ?> uriTemplateVariables = getTemplateVariables(req);
-      addMessageParams(uriTemplateVariables, lastEvent);
+      if (uriTemplateVariables != null) {
+        // If it has template variables, it's parameterized.
+        final String pattern = (String) req.getAttribute(BEST_MATCHING_PATTERN_ATTRIBUTE);
+        lastEvent.httpServerRequest.setNormalizedPath(pattern);
+
+        addMessageParams(uriTemplateVariables, lastEvent);
+      }
 
       recorder.addEventUpdate(lastEvent);
     }

--- a/agent/test/petclinic/petclinic.bats
+++ b/agent/test/petclinic/petclinic.bats
@@ -161,7 +161,7 @@ teardown_file() {
   local appmap="${output}"
   local reqid=$(jq '.events[] | select(.http_server_request.path_info == "/owners/1/pets/1/edit") | .id' <<< "${appmap}")
   run jq -r -e --arg reqid $reqid '.eventUpdates[$reqid] | .http_server_request.normalized_path_info, (.message[] | .name)' <<< "${appmap}"
-  assert_output '/owners/:ownerId/pets/:petId/edit
+  assert_output '/owners/{ownerId}/pets/{petId}/edit
 petId
 ownerId'
 }


### PR DESCRIPTION
Only set `normalized_path_info` for parameterized requests. Update the syntax so it matches v1.5.1 of the [AppMap spec](https://github.com/getappmap/appmap#http-server-request-call-attributes).

Fixes #151. Fixes #152.