### PR TITLE
fix: eliminate possibility of NPE

### DIFF
--- a/agent/src/main/java/com/appland/appmap/process/hooks/SqlQuery.java
+++ b/agent/src/main/java/com/appland/appmap/process/hooks/SqlQuery.java
@@ -32,7 +32,14 @@ public class SqlQuery {
   }
 
   private static boolean isMock(Object o) {
-    return o.getClass().getPackage().getName().startsWith("org.mockito");
+    final Class c = o.getClass();
+    final Package p = c.getPackage();
+    if (p == null) {
+      // If there's no package info, it's not a Mockito object.
+      return false;
+    }
+
+    return p.getName().startsWith("org.mockito");
   }
 
   private static String getDbName(Connection c) {


### PR DESCRIPTION
When SQLQuery tries to determine whether an object is a mock, it should not assume that the object has package info available.

We've seen this happen in the wild. I'm not sure why, though, so I don't know how to write a test for it.

Fixes #160 .