### PR TITLE
fix: Don't print exception when copying across filesystems fails

### DIFF
--- a/agent/src/main/java/com/appland/appmap/record/Recording.java
+++ b/agent/src/main/java/com/appland/appmap/record/Recording.java
@@ -58,6 +58,7 @@ public class Recording {
             },
         };
         List<String> errors = new ArrayList<>();
+        IOException lastException = null;
         try {
             Files.createDirectories(outputDirectory);
 
@@ -67,7 +68,7 @@ public class Recording {
                     errors.clear();
                     break;
                 }
-                r.exception.printStackTrace();
+                lastException = r.exception;
                 errors.add(r.exception.toString());
             }
         } catch (IOException e) {
@@ -76,6 +77,8 @@ public class Recording {
         }
 
         if (!errors.isEmpty()) {
+            if (lastException != null)
+                lastException.printStackTrace();
             throw new RuntimeException(String.join(", ", errors));
         }
 

--- a/agent/src/test/java/com/appland/appmap/record/RecorderTest.java
+++ b/agent/src/test/java/com/appland/appmap/record/RecorderTest.java
@@ -1,20 +1,29 @@
 package com.appland.appmap.record;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -24,12 +33,17 @@ import java.util.concurrent.Semaphore;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.alibaba.fastjson.JSON;
 import com.appland.appmap.output.v1.Event;
 
 public class RecorderTest {
+
+  @Rule
+  public final SystemErrRule systemErrRule = new SystemErrRule().enableLog();
 
   @Before
   public void before() throws Exception {
@@ -96,6 +110,71 @@ public class RecorderTest {
     }
     assertNotNull(exception);
     assertTrue(exception.toString().indexOf("java.lang.RuntimeException: ") == 0);
+  }
+
+  @Test
+  // for Files.move when: REPLACE_EXISTING, ATOMIC_MOVE
+  public void testWriteFileAcrossFilesystems() throws IOException {
+    //  /dev/shm exists only on Linux
+    assumeThat(System.getProperty("os.name"), is("Linux"));
+    systemErrRule.clearLog();
+    String sourceFilename = "/tmp/recordertest_file";
+    String targetFilename = "/dev/shm/recordertest_file";
+    File sourceFile = new File(sourceFilename);
+    File targetFile = new File(targetFilename);
+    Exception exception = null;
+    // if the file exists createNewFile returns false
+    sourceFile.createNewFile();
+
+    // Copying a file across filesystems should not throw an exception.
+    final Recording recording = new Recording("recorderName", sourceFile);
+    try {
+      recording.moveTo(targetFilename);
+    } catch (RuntimeException e) {
+      exception = e;
+      System.out.println(exception.getMessage());
+    } finally {
+      sourceFile.delete();
+      targetFile.delete();
+    }
+    assertNull("recording.moveTo failed, writing across filesystems threw an exception", exception);
+    assertFalse(systemErrRule.getLog().contains("Invalid cross-device link"));
+  }
+
+  @Test
+  // for Files.move when: REPLACE_EXISTING
+  public void testCantOverwriteTargetFile() throws IOException {
+    //  /dev/shm exists only on Linux
+    assumeThat(System.getProperty("os.name"), is("Linux"));
+    String sourceFilename = "/tmp/recordertest_file";
+    String targetFilename = "/dev/shm/recordertest_file";
+    File sourceFile = new File(sourceFilename);
+    File targetFile = new File(targetFilename);
+    Exception exception = null;
+    // if the file exists createNewFile returns false
+    sourceFile.createNewFile();
+    targetFile.createNewFile();
+
+    try {
+      // change permissions of destination file so it can't be overwritten
+      Set<PosixFilePermission> targetPermissions = PosixFilePermissions.fromString("---------");
+      Files.setPosixFilePermissions(targetFile.toPath(), targetPermissions);
+    } catch (IOException e) {
+    }
+
+    // Copying a file when the destination can't be overwritten should
+    // not throw an exception.
+    final Recording recording = new Recording("recorderName", sourceFile);
+    try {
+      recording.moveTo(targetFilename);
+    } catch (RuntimeException e) {
+      exception = e;
+      System.out.println(exception.getMessage());
+    } finally {
+      sourceFile.delete();
+      targetFile.delete();
+    }
+    assertNull("recording.moveTo failed, overwriting the destination threw an exception", exception);
   }
 
   @Test

--- a/agent/src/test/java/com/appland/appmap/record/RecorderTest.java
+++ b/agent/src/test/java/com/appland/appmap/record/RecorderTest.java
@@ -104,7 +104,7 @@ public class RecorderTest {
     final Recording recording = recorder.stop();
     Exception exception = null;
     try {
-      recording.moveTo("/no-such-directory");
+      recording.moveTo("/no-such-directory/.");
     } catch (RuntimeException e) {
       exception = e;
     }


### PR DESCRIPTION
Before this change, when `moveTo` copied a file across filesystems it triggered and caught an `AtomicMoveNotSupportedException` exception, printed it out, and then tried to copy the file in other ways which eventually succeeded.  This had the side  effect of printing the exception even though `moveTo` succeeded.

After this change, `moveTo` doesn't print any exceptions if it succeeds.

- Added two tests that verify the exceptions were and still are caught correctly.  They are the tests `testWriteFileAcrossFilesystems` and  `testCantOverwriteTargetFile`.  Didn't add a third test for the [third FileMover](https://github.com/getappmap/appmap-java/blob/master/agent/src/main/java/com/appland/appmap/record/Recording.java#L55) for Files.copy because it seems to be covered by [`testUnwriteableOutputFile`](https://github.com/getappmap/appmap-java/blob/master/agent/src/test/java/com/appland/appmap/record/RecorderTest.java#L87).
- <del>Added an integration test `agent/test/filemover` that verifies the `Invalid cross-device link` error message from the `AtomicMoveNotSupportedException` isn't printed.</del>

<del>Before the change in `Recording.java`, the new integration test failed.</del>

```
~/src/appmap-java$ ./gradlew build; rm agent/test/filemover/*class; bin/test; (cd agent; java -javaagent:build/libs/appmap-1.15.5.jar -cp test/filemover:build/classes/java/test -Dappmap.record.private=true FileMover)
16 actionable tasks: 3 executed, 13 up-to-date
1..1
not ok 1 moveTo
# (from function `refute_output' in file test/filemover/../../build/bats/bats-assert/src/refute_output.bash, line 189,
#  in test file test/filemover/filemover.bats, line 27)
#   `refute_output -p "Invalid cross-device link"' failed
Test command ./test/filemover/test failed
java.nio.file.AtomicMoveNotSupportedException: /tmp/recordertest_file -> /dev/shm/recordertest_file: Invalid cross-device link
	at java.base/sun.nio.fs.UnixCopyFile.move(UnixCopyFile.java:415)
	at java.base/sun.nio.fs.UnixFileSystemProvider.move(UnixFileSystemProvider.java:267)
	at java.base/java.nio.file.Files.move(Files.java:1422)
	at com.appland.appmap.record.Recording.lambda$moveTo$1(Recording.java:53)
	at com.appland.appmap.record.Recording.lambda$moveTo$0(Recording.java:45)
	at com.appland.appmap.record.Recording.moveTo(Recording.java:65)
	at FileMover.main(FileMover.java:28)
```

<del>After the change in `Recording.java`, the new integration test passes. </del>

```
~/src/appmap-java$ ./gradlew build; rm agent/test/filemover/*class; bin/test; (cd agent; java -javaagent:build/libs/appmap-1.15.5.jar -cp test/filemover:build/classes/java/test -Dappmap.record.private=true FileMover)
16 actionable tasks: 6 executed, 10 up-to-date
1..1
ok 1 moveTo
test@work[2023-02-06_12:00:30]:~/src/appmap-java$
```

Fixes https://github.com/getappmap/appmap-java/issues/162