### PR TITLE
ci: Fix deploying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,9 @@ script:
 - ./bin/test
 
 before_deploy:
+  - nvm install lts/*
   - |
-    nvm install --lts=gallium \
-      && nvm use --lts=gallium \
-      && npm i -g \
+    npm i -g \
         semantic-release \
         @semantic-release/exec \
         @semantic-release/git \


### PR DESCRIPTION
Deploying [breaks](https://app.travis-ci.com/github/getappmap/appmap-java/builds/260432108) because semantic-release [needs](https://app.travis-ci.com/github/getappmap/appmap-java/jobs/595398075#L503) node >= 18.
```
[semantic-release]: node version >=18 is required. Found v16.19.0.
```

To confirm this fix works, I tested this change in a [`before_install`](https://github.com/getappmap/appmap-java/commit/ad3790d675d52ab4b87e2cd6800ef160ee3063ae) section on branch `sw/fix_deploy__debug_ci`.  It worked on [CI](https://app.travis-ci.com/github/getappmap/appmap-java/jobs/595586760#L214).