### PR TITLE
ci: Use Jammy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 install: true
 os: linux
-dist: bionic
+dist: jammy
 jdk:
 - openjdk17
 - openjdk8


### PR DESCRIPTION
Node 18 (used by semantic release) needs >= GLIBC_2.28.
Focal provides GLIBC_2.28 but openjdk8 seems broken on it.
Jammy provides GLIBC_2.28 and openjdk8 works on it.  Use Jammy.