### PR TITLE
feat: generate a default config

### DIFF
--- a/agent/src/main/java/com/appland/appmap/Agent.java
+++ b/agent/src/main/java/com/appland/appmap/Agent.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.lang.instrument.Instrumentation;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+
 import com.appland.appmap.config.AppMapConfig;
 import com.appland.appmap.config.Properties;
 import com.appland.appmap.record.Recorder;
@@ -38,8 +39,12 @@ public class Agent {
     
     inst.addTransformer(new ClassFileTransformer());
 
-    if (AppMapConfig.load(new File(Properties.ConfigFile)) == null) {
-      Logger.printf("failed to load config %s\n", Properties.ConfigFile);
+    // If the user explicitly specified a config file, but the file doesn't
+    // exist, raise an error. They've almost certainly made a mistake.
+    boolean configSpecified = Properties.ConfigFile != null;
+    String configFile = !configSpecified ? "appmap.yml" : Properties.ConfigFile;
+    if (AppMapConfig.load(new File(configFile), configSpecified) == null) {
+      Logger.error("failed to load config %s\n", Properties.ConfigFile);
       System.exit(1);
     }
 
@@ -71,4 +76,5 @@ public class Agent {
       }));
     }
   }
+
 }

--- a/agent/src/main/java/com/appland/appmap/cli/Init.java
+++ b/agent/src/main/java/com/appland/appmap/cli/Init.java
@@ -1,24 +1,11 @@
 package com.appland.appmap.cli;
 
-import java.io.File;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.function.Consumer;
 
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.annotation.JSONField;
 import com.alibaba.fastjson.serializer.SerializerFeature;
+import com.appland.appmap.config.AppMapConfig;
 
 import picocli.CommandLine;
 
@@ -43,75 +30,11 @@ public class Init implements Callable<Integer> {
   public Integer call() throws Exception {
     System.err.printf("Init AppMap project configuration in directory: %s\n", parent.directory);
 
-    StringWriter sw = new StringWriter();
-    PrintWriter pw = new PrintWriter(sw);
-    pw.println("# This is the AppMap configuration file.");
-    pw.println("# For full documentation of this file for Java programs, see:");
-    pw.println("# https://appland.com/docs/reference/appmap-java.html#configuration");
-    pw.format("name: %s\n", CLI.projectName(new File(parent.directory)));
-
-    // For now, this only works in this type of standardize repo structure.
-    File javaDir = Paths.get(parent.directory).resolve("src/main/java").toFile();
-    if (javaDir.isDirectory()) {
-      // Collect package names in src/main/java
-      Set<Path> packages = new HashSet<>();
-      Files.walkFileTree(javaDir.toPath(), new SimpleFileVisitor<Path>() {
-        @Override
-        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-          if (file.getFileName().toString().endsWith(".java")) {
-            int pkgStart = javaDir.toPath().getNameCount();
-            int pkgEnd = file.getParent().getNameCount();
-            if (pkgStart == pkgEnd) {
-              // We're in the the unnamed package, ignore
-              return FileVisitResult.CONTINUE;
-            }
-
-            Path packagePath = file.getParent().subpath(pkgStart, pkgEnd);
-            if (packagePath.getNameCount() > 0) {
-              packages.add(packagePath);
-            }
-          }
-          return FileVisitResult.CONTINUE;
-        }
-      });
-
-      pw.println("# Your project contains the directory src/main/java.");
-      pw.println("# AppMap has auto-detected the following Java packages in this directory:");
-      pw.println("packages:");
-      // Collect just the packages that don't have a matching ancestor in the package list.
-      List<Path> topLevelPackages = packages.stream().sorted().collect(ArrayList::new, (memo, packagePath) -> {
-        for (int i = 1; i < packagePath.getNameCount(); i++) {
-          Path ancestorPath = packagePath.subpath(0, i);
-          if (memo.contains(ancestorPath)) {
-            return;
-          }
-        }
-        memo.add(packagePath);
-      }, ArrayList::addAll);
-      topLevelPackages.forEach(new Consumer<Path>() {
-        @Override
-        public void accept(Path packagePath) {
-          List<String> tokens = new ArrayList<>();
-          for (int i = 0; i < packagePath.getNameCount(); i++) {
-            tokens.add(packagePath.getName(i).toString());
-          }
-          String path = String.join(".", tokens);
-          pw.format("- path: %s\n", path);
-        }
-      });
-    } else {
-      pw.println("packages: []");
-      pw.println("# appmap-java init looks for source packages in src/main/java.");
-      pw.println("# This folder was not found in your project, so no packages were auto-detected.");
-      pw.println("# You can add your source packages by replacing the line above with lines like this:");
-      pw.println("# packages:");
-      pw.println("# - path: com.mycorp.pkg");
-      pw.println("# - path: org.otherstuff.pkg");
-    }
+    String contents = AppMapConfig.getDefault(parent.directory);
 
     Configuration configuration = new Configuration();
     configuration.filename = "appmap.yml";
-    configuration.contents = sw.toString();
+    configuration.contents = contents;
     Result result = new Result();
     result.configuration = configuration;
 

--- a/agent/src/main/java/com/appland/appmap/config/AppMapConfig.java
+++ b/agent/src/main/java/com/appland/appmap/config/AppMapConfig.java
@@ -3,13 +3,26 @@ package com.appland.appmap.config;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import com.appland.appmap.cli.CLI;
 import com.appland.appmap.util.FullyQualifiedName;
 import com.appland.appmap.util.Logger;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -21,11 +34,17 @@ public class AppMapConfig {
   public AppMapPackage[] packages = new AppMapPackage[0];
   private static AppMapConfig singleton = new AppMapConfig();
 
-  static File findConfig(File configFile) throws FileNotFoundException {
+  static File findConfig(File configFile, boolean mustExist) throws FileNotFoundException {
     if (configFile.exists()) {
       return configFile;
     }
-    Path parent = configFile.toPath().toAbsolutePath().getParent();
+
+    if (mustExist) {
+      throw new FileNotFoundException(configFile.toString());
+    }
+
+    Path projectDirectory = configFile.toPath().toAbsolutePath().getParent();
+    Path parent = projectDirectory;
     while (parent != null) {
       Path c = parent.resolve("appmap.yml");
       if (Files.exists(c)) {
@@ -34,19 +53,34 @@ public class AppMapConfig {
       parent = parent.getParent();
     }
 
+    try (
+        FileWriter fw = new FileWriter(configFile)) {
+      Files.createDirectories(projectDirectory);
+      fw.write(getDefault(projectDirectory.toString()));
+
+      return configFile;
+    } catch (IOException e) {
+      Logger.error("Failed to create default config\n");
+      Logger.error(e);
+    }
+
     throw new FileNotFoundException(configFile.toString());
   }
 
   /**
    * Populate the configuration from a file.
+   * 
    * @param configFile The file to be loaded
+   * @param mustExist  When true, the config must already exist; when false, it
+   *                   will be created if it doesn't exist.
+   *
    * @return The AppMapConfig singleton
    */
-  public static AppMapConfig load(File configFile) {
+  public static AppMapConfig load(File configFile, boolean mustExist) {
     InputStream inputStream = null;
 
     try {
-      configFile = AppMapConfig.findConfig(configFile);
+      configFile = AppMapConfig.findConfig(configFile, mustExist);
       Logger.println(String.format("using config file -> %s",
                                    configFile.getAbsolutePath()));
       inputStream = new FileInputStream(configFile);
@@ -130,5 +164,82 @@ public class AppMapConfig {
     }
 
     return false;
+  }
+
+  public static String getDefault(String directory) throws IOException {
+    StringWriter sw = new StringWriter();
+    PrintWriter pw = new PrintWriter(sw);
+    pw.println("# This is the AppMap configuration file.");
+    pw.println("# For full documentation of this file for Java programs, see:");
+    pw.println("# https://appland.com/docs/reference/appmap-java.html#configuration");
+    pw.format("name: %s\n", CLI.projectName(new File(directory)));
+
+    // For now, this only works in this type of standardize repo structure.
+    File javaDir = Paths.get(directory).resolve("src/main/java").toFile();
+    if (javaDir.isDirectory()) {
+      int pkgStart = javaDir.toPath().getNameCount();
+      // Collect package names in src/main/java
+      Set<Path> packages = new HashSet<>();
+      Files.walkFileTree(javaDir.toPath(), new SimpleFileVisitor<Path>() {
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+          if (file.getFileName().toString().endsWith(".java")) {
+            int pkgEnd = file.getParent().getNameCount();
+            if (pkgStart == pkgEnd) {
+              // We're in the the unnamed package, ignore
+              return FileVisitResult.CONTINUE;
+            }
+
+            Path packagePath = file.getParent().subpath(pkgStart, pkgEnd);
+            if (packagePath.getNameCount() > 0) {
+              packages.add(packagePath);
+            }
+          }
+          return FileVisitResult.CONTINUE;
+        }
+      });
+
+      pw.print("\n"
+          + "# Your project contains the directory src/main/java. AppMap has\n"
+          + "# auto-detected Java packages. By default, only classes in these\n"
+          + "# packages will be recorded. To record classes in subpackages, remove\n"
+          + "# the line(s)\n"
+          + "#   shallow: true\n"
+          + "\n"
+          + "packages:\n");
+
+      // Collect just the packages that don't have a matching ancestor in the package
+      // list.
+      List<Path> topLevelPackages = packages.stream().sorted().collect(ArrayList::new, (memo, packagePath) -> {
+        for (int i = 1; i < packagePath.getNameCount(); i++) {
+          Path ancestorPath = packagePath.subpath(0, i);
+          if (memo.contains(ancestorPath)) {
+            return;
+          }
+        }
+        memo.add(packagePath);
+      }, ArrayList::addAll);
+      topLevelPackages.forEach(new Consumer<Path>() {
+        @Override
+        public void accept(Path packagePath) {
+          List<String> tokens = new ArrayList<>();
+          for (int i = 0; i < packagePath.getNameCount(); i++) {
+            tokens.add(packagePath.getName(i).toString());
+          }
+          String path = String.join(".", tokens);
+          pw.format("- path: %s\n", path);
+          pw.format("  shallow: true\n");
+        }
+      });
+    } else {
+      pw.println("packages: []");
+      pw.println("# appmap-java init looks for source packages in src/main/java.");
+      pw.println("# This folder was not found in your project, so no packages were auto-detected.");
+      pw.println("# You can add your source packages by replacing the line above with lines like this:");
+      pw.println("# packages:");
+      pw.println("# - path: com.mycorp.pkg");
+      pw.println("# - path: org.otherstuff.pkg");
+    }
+    return sw.toString();
   }
 }

--- a/agent/src/main/java/com/appland/appmap/config/Properties.java
+++ b/agent/src/main/java/com/appland/appmap/config/Properties.java
@@ -1,9 +1,9 @@
 package com.appland.appmap.config;
 
-import com.appland.appmap.util.Logger;
-
 import java.io.File;
 import java.util.function.Function;
+
+import com.appland.appmap.util.Logger;
 
 public class Properties {
   public static final Boolean Debug = (System.getProperty("appmap.debug") != null);
@@ -25,7 +25,7 @@ public class Properties {
 
   public static final String DefaultConfigFile = "appmap.yml";
   public static final String ConfigFile = resolveProperty(
-      "appmap.config.file", DefaultConfigFile);
+      "appmap.config.file", (String) null);
 
   public static final Integer DefaultMaxValueSize = 1024;
   public static final Integer MaxValueSize = resolveProperty(

--- a/agent/src/main/java/com/appland/appmap/util/Logger.java
+++ b/agent/src/main/java/com/appland/appmap/util/Logger.java
@@ -1,10 +1,10 @@
 package com.appland.appmap.util;
 
-import com.appland.appmap.config.Properties;
-
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+
+import com.appland.appmap.config.Properties;
 
 public class Logger {
   private static PrintStream log = ensureLog();
@@ -29,10 +29,13 @@ public class Logger {
     log.printf("AppMap[" + Thread.currentThread() + "] [DEBUG]: " + format, args);
   }
 
-  public static void error(String msg) {
-    System.err.println("AppMap[" + Thread.currentThread() + "] [ERROR]: " + msg);
+  public static void error(String format, Object... args) {
+    System.err.printf("AppMap[" + Thread.currentThread() + "] [ERROR]: " + format, args);
   }
 
+  public static void error(Throwable t) {
+    t.printStackTrace();
+  }
   public static void whereAmI(String msg) {
     if (!Properties.Debug) {
       return;

--- a/agent/src/test/java/com/appland/appmap/config/AppMapConfigTest.java
+++ b/agent/src/test/java/com/appland/appmap/config/AppMapConfigTest.java
@@ -4,10 +4,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,14 +32,42 @@ public class AppMapConfigTest {
         System.setErr(originalErr);
     }
 
-    /**
-     * The test should pass since since issue 53 fix, the AppMapConfig logs to StdErr even if debug property is not
-     * set.
-     */
     @Test
-    public void load() {
-        // Trying to load appmap.yml in /tmp shouldn't work.
-        AppMapConfig.load(Paths.get(System.getProperty("java.io.tmpdir"), "appmap.yml").toFile());
+    public void loadBadDirectory() {
+        // Trying to load appmap.yml in non-existent directory shouldn't work.
+        Path badDir = Paths.get("/no-such-dir");
+        assertFalse(Files.exists(badDir));
+        AppMapConfig.load(badDir.resolve("appmap.yml").toFile(), false);
+        assertNotNull(errContent.toString());
+        assertTrue(errContent.toString().contains("file not found"));
+    }
+
+    @Test
+    public void createDefault() throws IOException {
+        // Just verify that the file gets created when it should. The contents
+        // get verified elsewhere.
+        Path configFile = Paths.get(System.getProperty("java.io.tmpdir"), "appmap.yml");
+        Files.deleteIfExists(configFile);
+        AppMapConfig.load(configFile.toFile(), false);
+        assertTrue(Files.exists(configFile));
+    }
+
+    @Test
+    public void preservesExisting() throws IOException {
+        Path tmpConfigFile = Files.createTempFile("appmap-config.", ".yml");
+        String expectedName = "not-a-real-app";
+        // This isn't the name in the default config
+        Files.write(tmpConfigFile, String.format("name: %s\n", expectedName).getBytes());
+        AppMapConfig actual = AppMapConfig.load(tmpConfigFile.toFile(), false);
+        assertEquals(expectedName, actual.name);
+    }
+
+    @Test
+    public void requiresExisting() throws IOException {
+        Path configFile = Paths.get(System.getProperty("java.io.tmpdir"), "appmap.yml");
+        Files.deleteIfExists(configFile);
+
+        AppMapConfig.load(configFile.toFile(), true);
         assertNotNull(errContent.toString());
         assertTrue(errContent.toString().contains("file not found"));
     }
@@ -45,7 +78,7 @@ public class AppMapConfigTest {
     public void loadParent() {
         File f = Paths.get("test", "appmap.yml").toFile();
         assertFalse(f.exists());
-        AppMapConfig.load(f);
+        AppMapConfig.load(f, false);
         File expected = Paths.get("appmap.yml").toAbsolutePath().toFile();
         assertTrue(expected.exists()); // sanity check
         assertEquals(expected, AppMapConfig.get().configFile);


### PR DESCRIPTION
If there's no appmap.yml in the current project, and the user hasn't explicitly specified one (by setting appmap.config.file), create one.

Fixes #169 .