### PR TITLE
fix: set attributes of http_client_request

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -53,6 +53,8 @@ dependencies {
   implementation 'org.slf4j:slf4j-nop:1.7.30'
   implementation 'info.picocli:picocli:4.6.1'
   implementation 'org.apache.httpcomponents:httpcore-nio:4.4.15'
+  implementation 'com.squareup.okhttp3:okhttp:4.9.3'
+
   
   // We have to refer to annotations by name (for example, see CodeObject), so
   // there's no need for a compile-time dependency on

--- a/agent/src/main/java/com/appland/appmap/config/AppMapConfig.java
+++ b/agent/src/main/java/com/appland/appmap/config/AppMapConfig.java
@@ -201,11 +201,7 @@ public class AppMapConfig {
 
       pw.print("\n"
           + "# Your project contains the directory src/main/java. AppMap has\n"
-          + "# auto-detected Java packages. By default, only classes in these\n"
-          + "# packages will be recorded. To record classes in subpackages, remove\n"
-          + "# the line(s)\n"
-          + "#   shallow: true\n"
-          + "\n"
+          + "# auto-detected the following Java packages in this directory:\n"
           + "packages:\n");
 
       // Collect just the packages that don't have a matching ancestor in the package
@@ -228,7 +224,6 @@ public class AppMapConfig {
           }
           String path = String.join(".", tokens);
           pw.format("- path: %s\n", path);
-          pw.format("  shallow: true\n");
         }
       });
     } else {

--- a/agent/src/main/java/com/appland/appmap/reflect/HttpServletRequest.java
+++ b/agent/src/main/java/com/appland/appmap/reflect/HttpServletRequest.java
@@ -13,7 +13,7 @@ public class HttpServletRequest extends ReflectiveType implements HttpHeaders {
   private final String GET_PARAMETER_MAP = "getParameterMap";
   private final String GET_ATTRIBUTE = "getAttribute";
   private final String SET_ATTRIBUTE = "setAttribute";
-  private final String GET_ATTRIBUTE_NAMES = "getAttributerNames";
+  private final String GET_ATTRIBUTE_NAMES = "getAttributeNames";
 
   public HttpServletRequest(Object self) {
     super(self);

--- a/agent/src/main/java/com/appland/appmap/reflect/apache/HttpEntity.java
+++ b/agent/src/main/java/com/appland/appmap/reflect/apache/HttpEntity.java
@@ -12,6 +12,11 @@ class HttpEntity extends ReflectiveType {
   }
 
   String getContentType() {
-    return new Header(invokeObjectMethod(GET_CONTENT_TYPE)).getValue();
+    Object obj = invokeObjectMethod(GET_CONTENT_TYPE);
+    if (obj == null) {
+      return "";
+    }
+
+    return new Header(obj).getValue();
   }
 }

--- a/agent/src/main/java/com/appland/appmap/reflect/apache/HttpResponse.java
+++ b/agent/src/main/java/com/appland/appmap/reflect/apache/HttpResponse.java
@@ -17,7 +17,12 @@ public class HttpResponse extends ReflectiveType {
   }
 
   public String getContentType() {
-    HttpEntity he = new HttpEntity(invokeObjectMethod(GET_ENTITY));
+    Object obj = invokeObjectMethod(GET_ENTITY);
+    if (obj == null) {
+      return "";
+    }
+
+    HttpEntity he = new HttpEntity(obj);
 
     return he.getContentType();
   }

--- a/agent/test/helper.bash
+++ b/agent/test/helper.bash
@@ -85,39 +85,47 @@ find_agent_jar() {
   echo "$PWD/build/libs/$(ls build/libs | grep 'appmap-[[:digit:]]')"
 }
 
+# Start a PetClinic server. Note that the output from the printf's in this
+# function don't get redirected, to make it easier to use from a shell. When you
+# run it from a setup function, you should redirect fd 3.
 start_petclinic() {
   mkdir -p test/petclinic/classes
   javac -d test/petclinic/classes test/petclinic/Props.java
 
-  export LOG_DIR=build/log
+  export LOG_DIR=$PWD/build/log
   mkdir -p ${LOG_DIR}
 
-  export LOG=build/fixtures/spring-petclinic/petclinic.log
+  export LOG=$PWD/build/fixtures/spring-petclinic/petclinic.log
   export WS_URL="http://localhost:8080"
 
-  printf 'checking for running Petclinic server' >&3
+  printf 'checking for running Petclinic server\n'
   
   if ! curl -Isf "${WS_URL}" >/dev/null 2>&1; then
     if [ $? -eq 7 ]; then
-      printf 'server already running' >&3
+      printf '  server already running\n'
       exit 1
     fi
   fi
 
-  printf 'getting set up' >&3
-  java -ea -Dappmap.debug -Dappmap.debug.file=${LOG_DIR}/petclinic-appmap.log -Dappmap.debug.hooks -Dappmap.config.file=test/petclinic/appmap.yml -javaagent:$(find_agent_jar) -jar build/fixtures/spring-petclinic/target/$(ls build/fixtures/spring-petclinic/target | grep 'spring-petclinic-[[:digit:]].*\.jar$') &> $LOG &
+  printf '  starting PetClinic\n'
+  WD=$PWD
+  AGENT_JAR="$(find_agent_jar)"
+
+  pushd build/fixtures/spring-petclinic >/dev/null
+  ./mvnw -Dspring-boot.run.agents=$AGENT_JAR -Dspring-boot.run.jvmArguments="-Dappmap.config.file=$WD/test/petclinic/appmap.yml -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005" spring-boot:run &>$LOG  3>&- &
+  popd >/dev/null
+
   export JVM_PID=$!
   while ! curl -Isf "${WS_URL}" >/dev/null; do
   if ! kill -0 "${JVM_PID}" 2> /dev/null; then
-    printf '. failed!\n\nprocess exited unexpectedly:\n' >&3
-    cat $LOG >&3
+    printf '  failed!\n\nprocess exited unexpectedly:\n'
+    cat $LOG 
     exit 1
   fi
 
-  printf '.' >&3
   sleep 1
   done
-  printf ' ok\n\n' >&3
+  printf '  ok\n\n'
 }
 
 stop_petclinic() {

--- a/agent/test/http_client/NoContentController.java
+++ b/agent/test/http_client/NoContentController.java
@@ -1,0 +1,15 @@
+package org.springframework.samples.petclinic.system;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class NoContentTypeController {
+
+	@RequestMapping("/no-content")
+	public HttpEntity<?> noContent() {
+		return HttpEntity.EMPTY;
+	}
+
+}

--- a/agent/test/http_client/http_client.bats
+++ b/agent/test/http_client/http_client.bats
@@ -5,21 +5,42 @@ load '../../build/bats/bats-assert/load'
 load '../helper'
 
 setup_file() {
-  start_petclinic
+  cp test/http_client/NoContentController.java build/fixtures/spring-petclinic/src/main/java/org/springframework/samples/petclinic/system/.
+  start_petclinic >&3
+
+  pushd test/http_client
 }
 
 teardown_file() {
+  popd
+
   stop_petclinic
 }
 
-@test "requests are recorded" {
-  pushd test/http_client
-
-  run ./gradlew -q run ${DEBUG} --args "${WS_URL}"
+@test "request without query" {
+  run ./gradlew -q run ${DEBUG} --args "${WS_URL}/vets"
 
   assert_json_eq '.events[1].http_client_request.request_method' "GET"
-  assert_json_eq '.events[1].http_client_request.url' "${WS_URL}/vets.html"
+  assert_json_eq '.events[1].http_client_request.url' "${WS_URL}/vets"
 
+  # Neither message nor parameters should set set
+  assert_json_eq '.events[1].message' ''
+  assert_json_eq '.events[1].parameters' ''
+}
+
+@test "request with query" {
+  run ./gradlew -q run ${DEBUG} --args "${WS_URL}/owners?lastName=davis"
+
+  assert_json_eq '.events[1].http_client_request.url' "${WS_URL}/owners"
+  assert_json_eq '.events[1].message | length' 1
+  assert_json_eq '.events[1].message[0] | "\(.name) \(.value)"' "lastName davis"
+  
   assert_json_eq '.events[2].http_client_response.status' "200"
 }
 
+@test "request without Content-Type" {
+  run ./gradlew --no-daemon -q run ${DEBUG} --args "${WS_URL}/no-content"
+
+  assert_json_eq '.events[1].http_client_request.url' "${WS_URL}/no-content"
+  assert_json_eq '.events[2].http_client_response.status' "200"
+}

--- a/agent/test/http_client/src/main/java/http_client/HttpClientTest.java
+++ b/agent/test/http_client/src/main/java/http_client/HttpClientTest.java
@@ -9,14 +9,14 @@ import com.appland.appmap.record.Recorder;
 import com.appland.appmap.record.Recording;
 
 public class HttpClientTest {
-  private String wsURL;
+  private String url;
+  private String contentType;
 
   public static void main(String[] argv) throws IOException {
-    final String WS_URL = argv[0];
 
     final Recording recording = Recorder.getInstance().record(() -> {
       try {
-        HttpClientTest.run(WS_URL);
+        new HttpClientTest(argv[0], argv.length > 1 ? argv[1] : null).run();
       } catch (IOException e) {
         e.printStackTrace();
       }
@@ -29,17 +29,17 @@ public class HttpClientTest {
     }
   }
 
-  public static void run(String wsURL) throws IOException {
-    new HttpClientTest(wsURL).getVets();
+  HttpClientTest(String url, String contentType) {
+    this.url = url;
+    this.contentType = contentType;
   }
 
-  public HttpClientTest(String wsURL) {
-    this.wsURL = wsURL;
+  public void run() throws IOException {
+    getURL();
   }
 
-  public int getVets() throws IOException {
-    return Request.Get(wsURL + "/vets.html")
+  public int getURL() throws IOException {
+    return Request.Get(url)
         .execute().returnResponse().getStatusLine().getStatusCode();
   }
-
 }

--- a/agent/test/petclinic/petclinic.bats
+++ b/agent/test/petclinic/petclinic.bats
@@ -11,7 +11,7 @@ load '../../build/bats/bats-assert/load'
 load '../helper'
 
 setup_file() {
-  start_petclinic
+  start_petclinic >&3
 }
 
 teardown_file() {


### PR DESCRIPTION
Make sure message and parameters are set correctly for an http_client_request. Also, make sure a response without Content-Type header or body is handled correctly.

Also, now that the VSCode does a good job of handling large AppMaps, don't set `shallow: true` when generating the default config.

Fixes #175 .