### PR TITLE
Hook HttpClient.execute methods that take an HttpHost

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -53,7 +53,7 @@ dependencies {
   implementation 'org.slf4j:slf4j-nop:1.7.30'
   implementation 'info.picocli:picocli:4.6.1'
   implementation 'org.apache.httpcomponents:httpcore-nio:4.4.15'
-  implementation 'com.squareup.okhttp3:okhttp:4.9.3'
+  implementation 'org.springframework:spring-web:5.3.27'
 
   
   // We have to refer to annotations by name (for example, see CodeObject), so

--- a/agent/src/main/java/com/appland/appmap/process/hooks/HttpServerRequest.java
+++ b/agent/src/main/java/com/appland/appmap/process/hooks/HttpServerRequest.java
@@ -20,12 +20,20 @@ import com.appland.appmap.util.Logger;
  */
 @Unique("http_server_request")
 public class HttpServerRequest {
+  // With the inclusion of org.springframework:spring-web as a dependency, both
+  // BEST_MATCHING_PATTERN_ATTRIBUTE and URI_TEMPLATE_VARIABLES_ATTRIBUTE now
+  // need to be generated at runtime. This works around the string-rewriting
+  // issue described in https://github.com/johnrengelman/shadow/issues/232 .
+
   // Needs to match
   // org.springframework.web.servlet.HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE
-  private static final String BEST_MATCHING_PATTERN_ATTRIBUTE = "org.springframework.web.servlet.HandlerMapping.bestMatchingPattern";
+  private static final String BEST_MATCHING_PATTERN_ATTRIBUTE = "org:springframework:web:servlet:HandlerMapping:bestMatchingPattern"
+      .replace(':', '.');
   // Needs to match
   // org.springframework.web.servlet.HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE
-  private static final String URI_TEMPLATE_VARIABLES_ATTRIBUTE = "org.springframework.web.servlet.HandlerMapping.uriTemplateVariables";
+  private static final String URI_TEMPLATE_VARIABLES_ATTRIBUTE = "org:springframework:web:servlet:HandlerMapping:uriTemplateVariables"
+      .replace(':', '.');
+
   private static final String LAST_EVENT_KEY = "com.appland.appmap.lastEvent";
   private static final Recorder recorder = Recorder.getInstance();
 

--- a/agent/src/main/java/com/appland/appmap/reflect/apache/HttpHost.java
+++ b/agent/src/main/java/com/appland/appmap/reflect/apache/HttpHost.java
@@ -1,0 +1,16 @@
+package com.appland.appmap.reflect.apache;
+
+import com.appland.appmap.reflect.ReflectiveType;
+
+public class HttpHost extends ReflectiveType {
+  private String TO_URI = "toURI";
+
+  public HttpHost(Object self) {
+    super(self);
+    addMethods(TO_URI);
+  }
+
+  public String toURI() {
+    return invokeStringMethod(TO_URI);
+  }
+}

--- a/agent/src/main/java/com/appland/appmap/reflect/apache/HttpRequest.java
+++ b/agent/src/main/java/com/appland/appmap/reflect/apache/HttpRequest.java
@@ -1,0 +1,22 @@
+package com.appland.appmap.reflect.apache;
+
+import com.appland.appmap.reflect.ReflectiveType;
+
+public class HttpRequest extends ReflectiveType {
+  private String GET_REQUEST_LINE = "getRequestLine";
+  RequestLine rl;
+
+  public HttpRequest(Object self) {
+    super(self);
+    addMethods(GET_REQUEST_LINE);
+    rl = new RequestLine(invokeObjectMethod(GET_REQUEST_LINE));
+  }
+
+  public String getMethod() {
+    return rl.getMethod();
+  }
+
+  public String getUri() {
+    return rl.getUri();
+  }
+}

--- a/agent/src/main/java/com/appland/appmap/reflect/apache/RequestLine.java
+++ b/agent/src/main/java/com/appland/appmap/reflect/apache/RequestLine.java
@@ -1,0 +1,22 @@
+package com.appland.appmap.reflect.apache;
+
+import com.appland.appmap.reflect.ReflectiveType;
+
+class RequestLine extends ReflectiveType {
+  private static String GET_METHOD = "getMethod";
+  private static String GET_URI = "getUri";
+
+  RequestLine(Object self) {
+    super(self);
+
+    addMethods(GET_METHOD, GET_URI);
+  }
+
+  String getMethod() {
+    return invokeStringMethod(GET_METHOD);
+  }
+
+  String getUri() {
+    return invokeStringMethod(GET_URI);
+  }
+}

--- a/agent/src/main/java/com/appland/appmap/transform/annotations/CtClassUtil.java
+++ b/agent/src/main/java/com/appland/appmap/transform/annotations/CtClassUtil.java
@@ -2,6 +2,8 @@ package com.appland.appmap.transform.annotations;
 
 import com.appland.appmap.config.Properties;
 import com.appland.appmap.util.Logger;
+
+import javassist.ClassPool;
 import javassist.CtClass;
 import javassist.NotFoundException;
 
@@ -70,5 +72,16 @@ class CtClassUtil {
 
   interface ClassAccessor<V> {
     V navigate() throws NotFoundException;
+  }
+
+  public static Boolean isChildOf(String childClassName, CtClass parentClass) {
+    ClassPool cp = ClassPool.getDefault();
+    try {
+      CtClass childClass = cp.get(childClassName);
+      return isChildOf(childClass, parentClass.getName());
+    } catch (NotFoundException e) {
+      Logger.println(e);
+    }
+    return false;
   }
 }

--- a/agent/src/main/java/com/appland/appmap/transform/annotations/HookClassSystem.java
+++ b/agent/src/main/java/com/appland/appmap/transform/annotations/HookClassSystem.java
@@ -61,10 +61,8 @@ public class HookClassSystem extends SourceMethodSystem {
       if (signatures != null || signature != null) {
         types = new ArrayList<Signature>();
         if (signatures != null) {
-          Logger.println("Found signatures");
           Collections.addAll(types, signatures);
         } else if (signature != null) {
-          Logger.println("Found single signature");
           types.add(signature);
         }
       }

--- a/agent/src/main/java/com/appland/appmap/transform/annotations/HookClassSystem.java
+++ b/agent/src/main/java/com/appland/appmap/transform/annotations/HookClassSystem.java
@@ -1,8 +1,16 @@
 package com.appland.appmap.transform.annotations;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+
 import com.appland.appmap.util.Logger;
+
 import javassist.CtBehavior;
+import javassist.CtClass;
+import javassist.NotFoundException;
 
 public class HookClassSystem extends SourceMethodSystem {
   private final static Boolean IGNORE_CHILDREN_DEFAULT = false;
@@ -11,10 +19,13 @@ public class HookClassSystem extends SourceMethodSystem {
   private String targetMethod = null;
   private Boolean ignoresChildren = IGNORE_CHILDREN_DEFAULT;
   private final Integer position;
+  private final static Signatures SIGNATURE_DEFAULT = null;
+  private List<Signature> signatures = null;
 
-  private HookClassSystem(CtBehavior behavior, int position) {
+  private HookClassSystem(CtBehavior behavior, int position, List<Signature> signatures) {
     super(behavior, HookClass.class);
     this.position = position;
+    this.signatures = signatures;
   }
 
   /**
@@ -42,10 +53,26 @@ public class HookClassSystem extends SourceMethodSystem {
           IGNORE_CHILDREN_DEFAULT);
 
       Integer position = AnnotationUtil.getPosition(behavior, HookClass.class, ISystem.HOOK_POSITION_DEFAULT);
-      HookClassSystem system = new HookClassSystem(behavior, position);
+
+      Signature[] signatures = (Signature[]) AnnotationUtil.getObject(behavior, Signatures.class, "value",
+          SIGNATURE_DEFAULT);
+      Signature signature = (Signature) behavior.getAnnotation(Signature.class);
+      List<Signature> types = null;
+      if (signatures != null || signature != null) {
+        types = new ArrayList<Signature>();
+        if (signatures != null) {
+          Logger.println("Found signatures");
+          Collections.addAll(types, signatures);
+        } else if (signature != null) {
+          Logger.println("Found single signature");
+          types.add(signature);
+        }
+      }
+
+      HookClassSystem system = new HookClassSystem(behavior, position, types);
       system.ignoresChildren = ignoresChildren;
       system.targetClass = hookClass.value();
-      system.targetMethod = hookClass.method() == null || hookClass.method().isEmpty() 
+      system.targetMethod = hookClass.method() == null || hookClass.method().isEmpty()
           ? behavior.getName()
           : hookClass.method();
 
@@ -58,16 +85,34 @@ public class HookClassSystem extends SourceMethodSystem {
 
   @Override
   public Boolean match(CtBehavior behavior, Map<String, Object> matchResult) {
+    String behaviorClass = behavior.getDeclaringClass().getName();
+
     if (this.ignoresChildren) {
-      if (!behavior.getDeclaringClass().getName().equals(this.targetClass)) {
+      if (!behaviorClass.equals(this.targetClass)) {
         return false;
       }
     } else if (!CtClassUtil.isChildOf(behavior.getDeclaringClass(), this.targetClass)) {
       return false;
     }
 
-    if (!behavior.getName().equals(this.targetMethod)) {
+    String behaviorName = behavior.getName();
+    if (!behaviorName.equals(this.targetMethod)) {
       return false;
+    }
+
+    if (signatures != null) {
+      try {
+        for (Signature signature : signatures) {
+          if (methodMatchesSignature(behavior, signature)) {
+            return true;
+          }
+        }
+        return false;
+      } catch (NotFoundException e) {
+        Logger.println("Failed to find type of parameters of " + behaviorClass + "."
+            + behaviorName);
+        Logger.println(e);
+      }
     }
 
     return true;
@@ -81,5 +126,22 @@ public class HookClassSystem extends SourceMethodSystem {
   @Override
   public Integer getHookPosition() {
     return position;
+  }
+
+  private static Boolean methodMatchesSignature(CtBehavior behavior, Signature signature) throws NotFoundException {
+    // CtBehavior.getParameterTypes finds the class of the parameter by
+    // name, and so can throw a NotFoundException.
+    List<CtClass> behaviorTypes = Arrays.asList(behavior.getParameterTypes());
+    String[] types = signature.value();
+    if (behaviorTypes.size() != types.length) {
+      return false;
+    }
+    for (int i = 0; i < types.length; i++) {
+      if (!CtClassUtil.isChildOf(behaviorTypes.get(i), types[i])) {
+        return false;
+      }
+    }
+
+    return true;
   }
 }

--- a/agent/src/main/java/com/appland/appmap/transform/annotations/Signature.java
+++ b/agent/src/main/java/com/appland/appmap/transform/annotations/Signature.java
@@ -1,0 +1,18 @@
+package com.appland.appmap.transform.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A method with this annotation will only be hooked if the names of the types
+ * of its arguments match the types passed.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Repeatable(Signatures.class)
+public @interface Signature {
+  public String[] value();
+}

--- a/agent/src/main/java/com/appland/appmap/transform/annotations/Signatures.java
+++ b/agent/src/main/java/com/appland/appmap/transform/annotations/Signatures.java
@@ -1,0 +1,12 @@
+package com.appland.appmap.transform.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Signatures {
+  Signature[] value();
+}

--- a/agent/src/test/java/com/appland/appmap/transform/annotations/ArgumentArraySystemTest.java
+++ b/agent/src/test/java/com/appland/appmap/transform/annotations/ArgumentArraySystemTest.java
@@ -90,6 +90,8 @@ public class ArgumentArraySystemTest {
       hooks.add(hook);
     }
 
+    assertTrue("No hooks?", hooks.size() > 0);
+
     for (CtBehavior behavior : targetClass.getDeclaredBehaviors()) {
       Map<String, Object> matchResult = new HashMap<String, Object>();
       hooks.stream()

--- a/agent/src/test/java/com/appland/appmap/transform/annotations/HookClassSystemTest.java
+++ b/agent/src/test/java/com/appland/appmap/transform/annotations/HookClassSystemTest.java
@@ -79,7 +79,10 @@ public class HookClassSystemTest {
     for (CtMethod behavior : hookClass.getDeclaredMethods()) {
       Hook hook = Hook.from(behavior);
       assertNotNull(hook);
+      hooks.add(hook);
     }
+
+    assertTrue("No hooks?", hooks.size() > 0);
 
     for (CtBehavior behavior : targetClass.getDeclaredBehaviors()) {
       Map<String, Object> matchResult = new HashMap<String, Object>();

--- a/agent/test/helper.bash
+++ b/agent/test/helper.bash
@@ -96,7 +96,8 @@ start_petclinic() {
   mkdir -p ${LOG_DIR}
 
   export LOG=$PWD/build/fixtures/spring-petclinic/petclinic.log
-  export WS_URL="http://localhost:8080"
+  export WS_SCHEME="http" WS_HOST="localhost" WS_PORT="8080"
+  export WS_URL="${WS_SCHEME}://${WS_HOST}:${WS_PORT}"
 
   printf 'checking for running Petclinic server\n'
   
@@ -112,7 +113,7 @@ start_petclinic() {
   AGENT_JAR="$(find_agent_jar)"
 
   pushd build/fixtures/spring-petclinic >/dev/null
-  ./mvnw -Dspring-boot.run.agents=$AGENT_JAR -Dspring-boot.run.jvmArguments="-Dappmap.config.file=$WD/test/petclinic/appmap.yml -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005" spring-boot:run &>$LOG  3>&- &
+  ./mvnw -Dspring-boot.run.agents=$AGENT_JAR -Dspring-boot.run.jvmArguments="-Dappmap.config.file=$WD/test/petclinic/appmap.yml -Dappmap.debug" spring-boot:run &>$LOG  3>&- &
   popd >/dev/null
 
   export JVM_PID=$!

--- a/agent/test/http_client/build.gradle
+++ b/agent/test/http_client/build.gradle
@@ -18,13 +18,13 @@ sourceSets {
 // TODO: look at consolidating this with the gradle config in httpcore
 def appmapJar = fileTree('../../build/libs').matching {
       include {
-        it.file.name ==~ /.*appmap-[0-9.]*.jar$/
+        it.file.name ==~ /.*appmap-[0-9.]*(-SNAPSHOT)*.jar$/
       }
     }.getFiles()[0]
 
 def annotationJar = fileTree('../../../annotation/build/libs').matching {
       include {
-        it.file.name ==~ /.*annotation-[0-9.]*.jar$/
+        it.file.name ==~ /.*annotation-[0-9.]*(-SNAPSHOT)*.jar$/
       }
     }.getFiles()[0]
 
@@ -41,12 +41,13 @@ dependencies {
 }
 
 application {
+  // mainClass = 'http_client.HttpClientTest'
   mainClassName = project.hasProperty("mainClass") ? project.getProperty("mainClass") : "NULL"
   applicationDefaultJvmArgs = [
     "-javaagent:${appmapJar}", 
     "-Dappmap.config.file=appmap.yml", 
-    // "-Dappmap.debug=true", 
-    // "-Dappmap.debug.file=../../build/logs/httpclient-appmap.log"
+    //"-Dappmap.debug=true", 
+    //"-Dappmap.debug.file=../../build/log/httpclient-appmap.log"
   ]
 
 }

--- a/agent/test/http_client/build.gradle
+++ b/agent/test/http_client/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 }
 
 application {
-  mainClass = 'http_client.HttpClientTest'
+  mainClassName = project.hasProperty("mainClass") ? project.getProperty("mainClass") : "NULL"
   applicationDefaultJvmArgs = [
     "-javaagent:${appmapJar}", 
     "-Dappmap.config.file=appmap.yml", 

--- a/agent/test/http_client/src/main/java/http_client/HttpHostTest.java
+++ b/agent/test/http_client/src/main/java/http_client/HttpHostTest.java
@@ -3,19 +3,24 @@ package http_client;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 
-import org.apache.http.client.fluent.Request;
+import org.apache.http.HttpHost;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClients;
 
 import com.appland.appmap.record.Recorder;
 import com.appland.appmap.record.Recording;
 
-public class HttpClientTest {
-  private String url;
+public class HttpHostTest {
+  private String host;
+  private int port;
+  private String path;
 
   public static void main(String[] argv) throws IOException {
 
     final Recording recording = Recorder.getInstance().record(() -> {
       try {
-        new HttpClientTest(argv[0], argv.length > 1 ? argv[1] : null).run();
+        new HttpHostTest(argv[0], Integer.parseInt(argv[1]), argv[2]).run();
       } catch (IOException e) {
         e.printStackTrace();
       }
@@ -28,8 +33,10 @@ public class HttpClientTest {
     }
   }
 
-  HttpClientTest(String url, String contentType) {
-    this.url = url;
+  HttpHostTest(String host, int port, String path) {
+    this.host = host;
+    this.port = port;
+    this.path = path;
   }
 
   public void run() throws IOException {
@@ -37,7 +44,7 @@ public class HttpClientTest {
   }
 
   public int getURL() throws IOException {
-    return Request.Get(url)
-        .execute().returnResponse().getStatusLine().getStatusCode();
+    HttpClient client = HttpClients.createDefault();
+    return client.execute(new HttpHost(host, port), new HttpGet(path)).getStatusLine().getStatusCode();
   }
 }

--- a/agent/test/httpcore/build.gradle
+++ b/agent/test/httpcore/build.gradle
@@ -17,13 +17,13 @@ sourceSets {
 
 def appmapJar = fileTree('../../build/libs').matching {
       include {
-        it.file.name ==~ /.*appmap-[0-9.]*.jar$/
+        it.file.name ==~ /.*appmap-[0-9.]*(-SNAPSHOT)*.jar$/
       }
     }.getFiles()[0]
 
 def annotationJar = fileTree('../../../annotation/build/libs').matching {
       include {
-        it.file.name ==~ /.*annotation-[0-9.]*.jar$/
+        it.file.name ==~ /.*annotation-[0-9.]*(-SNAPSHOT)*.jar$/
       }
     }.getFiles()[0]
 

--- a/agent/test/jdbc/build.gradle
+++ b/agent/test/jdbc/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 
 def appmapJar = fileTree('../../build/libs').matching {
       include {
-        it.file.name ==~ /.*appmap-[0-9.]*.jar$/
+        it.file.name ==~ /.*appmap-[0-9.]*(-SNAPSHOT)*.jar$/
       }
     }.getFiles()[0]
 
@@ -32,6 +32,6 @@ test {
 		"-javaagent:${appmapJar}", 
     "-Dappmap.config.file=appmap.yml", 
     // "-Dappmap.debug=true", 
-    "-Dappmap.debug.file=../../build/logs/jdbc-appmap.log"
+    "-Dappmap.debug.file=../../build/log/jdbc-appmap.log"
 	]
 }


### PR DESCRIPTION
Hook a couple more overloads of the `execute` method in `org.apache.http.client.HttpClient`. These changes also include a mechanism to make it easier to hook overloaded methods. They also switch from using `okhttp` to using `spring-web` for URL parsing.

Fixes #177 .