### PR TITLE
fix: don't depend on spring-web

### DIFF
--- a/agent/bin/test_install
+++ b/agent/bin/test_install
@@ -1,34 +1,55 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 
 fixture_dir=$PWD/build/fixtures
 mkdir -p build/fixtures
 
-(
-cd build/fixtures
 source "$JAVA_HOME/release"
+export JAVA_VERSION
 
-rm -rf spring-petclinic
-git clone https://github.com/spring-projects/spring-petclinic.git
-cd spring-petclinic
+function install_petclinic (
+  local repo="$1"; shift
+  local oldVersion="$1"
+  local pkg="$(basename $repo)"
 
-echo "${JAVA_VERSION}"
-case "${JAVA_VERSION}" in
-  1.8*)
-    ;&
-  11.*)
-    # PetClinic now requires Java 17. When we're testing older JDKs, use the
-    # last version that supported 1.8 (and 11). Note that they don't tag
-    # versions, so we just use the commit SHA. (We don't use the full hash,
-    # though, because Travis detects that as a secret. :( 8 digits should be
-    # enough to make a collision extremely unlikely.)
-    git checkout 9cb8dde9
-    ;;
-esac
-./mvnw -q package -Dmaven.test.skip=true
+  cd build/fixtures
+
+  rm -rf "${pkg}"
+  git clone https://github.com/"${repo}".git
+  cd "${pkg}"
+
+  echo "${JAVA_VERSION}"
+  if [[ ! -z $oldVersion ]]; then 
+    case "${JAVA_VERSION}" in
+      1.8*)
+        ;&
+      11.*)
+        git checkout "${oldVersion}" 
+        ;;
+    esac
+    ./mvnw package -Dmaven.test.skip=true
+  else
+    case "${JAVA_VERSION}" in
+      1.8*)
+        ;&
+      11.*)
+        echo "No old version, not packaging in ${pkg}"
+        ;;
+      17.*)
+        ./mvnw package -Dmaven.test.skip=true
+        ;;
+    esac
+  fi
 )
 
+# PetClinic now requires Java 17. When we're testing older JDKs, use the last
+# version that supported 1.8 (and 11). Note that spring-projects/petclinic
+# doesn't tag versions, so we just use the commit SHA. (We don't use the full
+# hash, though, because Travis detects that as a secret. :( 8 digits should be
+# enough to make a collision extremely unlikely.)
+install_petclinic "spring-projects/spring-petclinic" 9cb8dde9
+install_petclinic "spring-petclinic/spring-framework-petclinic"
 export BATS_DIR=$PWD/build/bats
 mkdir -p build/bats
 

--- a/agent/bin/test_run
+++ b/agent/bin/test_run
@@ -14,6 +14,9 @@ report_failure() {
 trap 'report_failure $LINENO' ERR
 
 ./test/petclinic/test
+if [[ $JAVA_VERSION == 17.* ]]; then
+  ./test/petclinic-fw/test
+fi
 ./test/httpcore/test
 ./test/http_client/test
 ./test/agent_cli/test

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -59,7 +59,6 @@ dependencies {
   implementation 'org.slf4j:slf4j-nop:1.7.30'
   implementation 'info.picocli:picocli:4.6.1'
   implementation 'org.apache.httpcomponents:httpcore-nio:4.4.15'
-  implementation 'org.springframework:spring-web:5.3.27'
 
   implementation "org.tinylog:tinylog-api:${tinylogVersion}"
   implementation "org.tinylog:tinylog-impl:${tinylogVersion}"
@@ -96,6 +95,8 @@ shadowJar {
   baseName = 'appmap'
   classifier = ''
   minimize() {
+    // tinylog computes the dependencies it needs at runtime, so don't exclude
+    // anything.
     exclude(dependency('org.tinylog:.*:.*'))
   }
 

--- a/agent/src/main/java/com/appland/appmap/transform/ClassFileTransformer.java
+++ b/agent/src/main/java/com/appland/appmap/transform/ClassFileTransformer.java
@@ -102,9 +102,12 @@ public class ClassFileTransformer implements java.lang.instrument.ClassFileTrans
   }
 
   private void processClass(CtClass ctClass) {
+    logger.trace(() -> ctClass.getName());
     for (CtBehavior behavior : ctClass.getDeclaredBehaviors()) {
+      logger.trace(() -> behavior.getLongName());
       Hook hook = Hook.from(behavior);
       if (hook == null) {
+        logger.trace("{}, no hooks", () -> behavior.getLongName());
         continue;
       }
 
@@ -113,8 +116,7 @@ public class ClassFileTransformer implements java.lang.instrument.ClassFileTrans
       try {
         hook.validate();
       } catch (HookValidationException e) {
-        Logger.println("failed to validate hook");
-        Logger.println(e);
+        logger.debug(e, "failed to validate hook");
         continue;
       }
 

--- a/agent/src/main/java/com/appland/appmap/transform/annotations/HookClassSystem.java
+++ b/agent/src/main/java/com/appland/appmap/transform/annotations/HookClassSystem.java
@@ -88,6 +88,8 @@ public class HookClassSystem extends SourceMethodSystem {
 
   @Override
   public Boolean match(CtBehavior behavior, Map<String, Object> matchResult) {
+    logger.trace(() -> behavior.getLongName());
+
     String behaviorClass = behavior.getDeclaringClass().getName();
     if (this.ignoresChildren) {
       if (!behaviorClass.equals(this.targetClass)) {
@@ -99,7 +101,9 @@ public class HookClassSystem extends SourceMethodSystem {
     logger.trace("behaviorClass {} isChildOf targetClass: {}", behaviorClass, targetClass);
 
     String behaviorName = behavior.getName();
-    logger.trace("behavior: {} hookBehavior: {}", behavior.getLongName(), getHookBehavior().getLongName());
+    if (logger.isTraceEnabled()) {
+      logger.trace("behavior: {} hookBehavior: {}", behavior.getLongName(), getHookBehavior().getLongName());
+    }
 
     if (!behaviorName.equals(this.targetMethod)) {
       return false;

--- a/agent/test/petclinic-fw/appmap.yml
+++ b/agent/test/petclinic-fw/appmap.yml
@@ -1,0 +1,3 @@
+name: Spring Pet Clinic
+packages:
+- path: org.springframework.samples.petclinic

--- a/agent/test/petclinic-fw/petclinic-fw.bats
+++ b/agent/test/petclinic-fw/petclinic-fw.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load '../../build/bats/bats-support/load'
+load '../../build/bats/bats-assert/load'
+load '../helper'
+
+setup_file() {
+  start_petclinic_fw >&3
+}
+
+teardown_file() {
+  stop_petclinic
+}
+
+@test "requests are recorded by default" {
+  run _curl -XGET "${WS_URL}/owners/1/pets/1/edit"
+  assert_success 
+  local dir='build/fixtures/spring-framework-petclinic/tmp/appmap/request_recording'
+  
+  run bash -o pipefail -c "ls -t ${dir}/*owners_1_pets_1_edit.appmap.json | head -1"
+  assert_success
+
+  output="$(<${output})"
+  assert_json_eq '.events[] | .http_server_request | .path_info' '/owners/1/pets/1/edit' 
+}

--- a/agent/test/petclinic-fw/test
+++ b/agent/test/petclinic-fw/test
@@ -1,0 +1,2 @@
+#!/bin/bash
+bats --tap test/petclinic-fw"${@}"


### PR DESCRIPTION
Remove the dependency on org.springframework:spring-web, it should have been removed as part of the changes to implement request recording.

Its inclusion prevents hooking of
SpringServletContainerInitializer.onStartup, which keeps request recording doesn't work for a Spring app deployed as a WAR. So, these changes also add a test for such an app.