### PR TITLE
Don't generate AppMaps for static resources

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -52,7 +52,6 @@ dependencies {
   implementation 'com.alibaba:fastjson:1.2.83'
   implementation "org.javassist:javassist:${javassistVersion}"
   implementation 'org.reflections:reflections:0.9.11'
-  implementation 'javax.servlet:javax.servlet-api:4.0.1'
   implementation 'org.apache.commons:commons-lang3:3.10'
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2'  
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
@@ -102,7 +101,6 @@ shadowJar {
   }
 
   dependencies {
-    exclude(dependency('javax.servlet:javax.servlet-api:4.0.1'))
     exclude(dependency('org.apache.httpcomponents:.*:.*'))
  }
 }
@@ -152,7 +150,6 @@ task relocateShadowJar(type: ShadowRelocation) {
   target = tasks.shadowJar
   prefix = "com.appland.shade"
   excludes = [
-    "javax.",
     "java.",
     "org.apache.http",
   ]

--- a/agent/src/main/java/com/appland/appmap/process/hooks/RequestRecording.java
+++ b/agent/src/main/java/com/appland/appmap/process/hooks/RequestRecording.java
@@ -71,4 +71,11 @@ public class RequestRecording {
     recording.moveTo(filename);
   }
 
+  /**
+   * abort stops the current thread's recording and throws it away.
+   */
+  public static void abort() {
+    Recorder.getInstance().stopThread();
+  }
+
 }

--- a/agent/src/main/java/com/appland/appmap/process/hooks/http/HttpServerRequest.java
+++ b/agent/src/main/java/com/appland/appmap/process/hooks/http/HttpServerRequest.java
@@ -27,19 +27,13 @@ public class HttpServerRequest {
   private static final String PACKAGE_NAME = MethodHandles.lookup().lookupClass().getPackage().getName();
   public static final String STATUS_ATTRIBUTE = PACKAGE_NAME + ".status";
 
-  // With the inclusion of org.springframework:spring-web as a dependency, both
-  // BEST_MATCHING_PATTERN_ATTRIBUTE and URI_TEMPLATE_VARIABLES_ATTRIBUTE now
-  // need to be generated at runtime. This works around the string-rewriting
-  // issue described in https://github.com/johnrengelman/shadow/issues/232 .
-
   // Needs to match
   // org.springframework.web.servlet.HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE
-  private static final String BEST_MATCHING_PATTERN_ATTRIBUTE = "org:springframework:web:servlet:HandlerMapping:bestMatchingPattern"
-      .replace(':', '.');
+  private static final String BEST_MATCHING_PATTERN_ATTRIBUTE = "org.springframework.web.servlet.HandlerMapping.bestMatchingPattern";
+
   // Needs to match
   // org.springframework.web.servlet.HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE
-  private static final String URI_TEMPLATE_VARIABLES_ATTRIBUTE = "org:springframework:web:servlet:HandlerMapping:uriTemplateVariables"
-      .replace(':', '.');
+  private static final String URI_TEMPLATE_VARIABLES_ATTRIBUTE = "org.springframework.web.servlet.HandlerMapping.uriTemplateVariables";
 
   private static final String LAST_EVENT_KEY = PACKAGE_NAME + ".lastEvent";
   private static final Recorder recorder = Recorder.getInstance();

--- a/agent/src/main/java/com/appland/appmap/reflect/HttpServletRequest.java
+++ b/agent/src/main/java/com/appland/appmap/reflect/HttpServletRequest.java
@@ -7,6 +7,10 @@ import java.util.Map;
 import com.appland.appmap.process.hooks.http.ServletContext;
 
 public class HttpServletRequest extends ReflectiveType implements HttpHeaders {
+  // Needs to match
+  // org.springframework.web.servlet.HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE
+  private static final String RESOURCE_URL_PROVIDER = "org.springframework.web.servlet.resource.ResourceUrlProvider";
+
   private final HttpHeaderDelegate headerDelegate;
 
   private final String GET_METHOD = "getMethod";
@@ -17,12 +21,14 @@ public class HttpServletRequest extends ReflectiveType implements HttpHeaders {
   private final String SET_ATTRIBUTE = "setAttribute";
   private final String GET_ATTRIBUTE_NAMES = "getAttributeNames";
   private final String GET_SERVLET_CONTEXT = "getServletContext";
+  private final String GET_SERVLET_PATH = "getServletPath";
 
   public HttpServletRequest(Object self) {
     super(self);
     this.headerDelegate = new HttpHeaderDelegate(self);
     
-    addMethods(GET_METHOD, GET_REQUEST_URI, GET_PROTOCOL, GET_PARAMETER_MAP, GET_ATTRIBUTE_NAMES, GET_SERVLET_CONTEXT);
+    addMethods(GET_METHOD, GET_REQUEST_URI, GET_PROTOCOL, GET_PARAMETER_MAP, GET_ATTRIBUTE_NAMES, GET_SERVLET_CONTEXT,
+        GET_SERVLET_PATH);
     addMethod(GET_ATTRIBUTE, String.class);
     addMethod(SET_ATTRIBUTE, String.class, Object.class);
   }
@@ -60,8 +66,34 @@ public class HttpServletRequest extends ReflectiveType implements HttpHeaders {
     return new ServletContext(invokeObjectMethod(GET_SERVLET_CONTEXT));
   }
 
+  public String getServletPath() {
+    return invokeStringMethod(GET_SERVLET_PATH);
+  }
+
   @Override
   public HttpHeaderDelegate getHeaderDelegate() {
     return headerDelegate;
+  }
+
+  private static class ResourceUrlProvider extends ReflectiveType {
+    private static String GET_FOR_LOOKUP_PATH = "getForLookupPath";
+
+    public ResourceUrlProvider(Object self) {
+      super(self);
+      addMethod(GET_FOR_LOOKUP_PATH, String.class);
+    }
+
+    public String getForLookupPath(String path) {
+      return invokeStringMethod(GET_FOR_LOOKUP_PATH, path);
+    }
+  }
+
+  public boolean isForStaticResource() {
+    Object obj = getAttribute(RESOURCE_URL_PROVIDER);
+    if (obj == null) {
+      return false;
+    }
+    ResourceUrlProvider provider = new ResourceUrlProvider(obj);
+    return provider.getForLookupPath(getServletPath()) != null;
   }
 }

--- a/agent/test/helper.bash
+++ b/agent/test/helper.bash
@@ -3,7 +3,7 @@
 # Helper methods for tests
 
 _curl() {
-  curl -H 'Accept: application/json' "${@}"
+  curl -sfH 'Accept: application/json,*/*' "${@}"
 }
 
 _appmap() {

--- a/agent/test/httpcore/httpcore.bats
+++ b/agent/test/httpcore/httpcore.bats
@@ -12,7 +12,6 @@ load '../helper'
 
 @test "the recording status reports disabled when not recording" {
   run _curl -sXGET "${WS_URL}/_appmap/record"
-
   assert_success
 
   assert_json_eq '.enabled' 'false'
@@ -20,7 +19,6 @@ load '../helper'
 
 @test "successfully start a new recording" {
   run _curl -sIXPOST "${WS_URL}/_appmap/record"
-
   assert_success
   
   echo "${output}" \
@@ -33,18 +31,17 @@ load '../helper'
   _curl -XGET "${WS_URL}"
 
   run _curl -sXGET "${WS_URL}/_appmap/record/checkpoint"
+  assert_success
 
   assert_json '.classMap'
   assert_json '.events'
   assert_json '.version'
 
   run _curl -sXGET "${WS_URL}/_appmap/record"
-
   assert_success
   assert_json_eq '.enabled' 'true'
 
   run _curl -sXDELETE "${WS_URL}/_appmap/record"
-
   assert_success
 
   assert_json '.classMap'
@@ -57,7 +54,6 @@ load '../helper'
   
   _curl -XGET "${WS_URL}"
   run _curl -sXDELETE "${WS_URL}/_appmap/record"
-
   assert_success
 
   assert_json '.classMap'

--- a/agent/test/petclinic-fw/petclinic-fw.bats
+++ b/agent/test/petclinic-fw/petclinic-fw.bats
@@ -4,6 +4,8 @@ load '../../build/bats/bats-support/load'
 load '../../build/bats/bats-assert/load'
 load '../helper'
 
+load '../petclinic-shared/static-resources.bash'
+
 setup_file() {
   start_petclinic_fw >&3
   export FIXTURE_DIR=build/fixtures/spring-framework-petclinic
@@ -35,14 +37,10 @@ setup() {
   assert_json '.classMap'
 }
 
-@test "requests are recorded by default" {
-  run _curl -sXGET "${WS_URL}/owners/1/pets/1/edit"
-  assert_success 
-  local dir="${FIXTURE_DIR}/target/tmp/appmap/request_recording"
-  
-  run bash -o pipefail -c "ls -t ${dir}/*owners_1_pets_1_edit.appmap.json | head -1"
-  assert_success
+@test "requests for non-static resources are recorded by default" {
+  test_requests_for_nonstatic_resources_are_recorded_by_default
+}
 
-  output="$(<${output})"
-  assert_json_eq '.events[] | .http_server_request | .path_info' '/owners/1/pets/1/edit' 
+@test "request for static resources don't generate recordings" {
+  test_request_for_static_resources_dont_generate_recordings
 }

--- a/agent/test/petclinic-fw/petclinic-fw.bats
+++ b/agent/test/petclinic-fw/petclinic-fw.bats
@@ -6,10 +6,15 @@ load '../helper'
 
 setup_file() {
   start_petclinic_fw >&3
+  export FIXTURE_DIR=build/fixtures/spring-framework-petclinic
 }
 
 teardown_file() {
   stop_ws
+}
+
+setup() {
+  rm -rf "${FIXTURE_DIR}/target/tmp/appmap"
 }
 
 @test "remote recording works" { 
@@ -33,7 +38,7 @@ teardown_file() {
 @test "requests are recorded by default" {
   run _curl -sXGET "${WS_URL}/owners/1/pets/1/edit"
   assert_success 
-  local dir='build/fixtures/spring-framework-petclinic/target/tmp/appmap/request_recording'
+  local dir="${FIXTURE_DIR}/target/tmp/appmap/request_recording"
   
   run bash -o pipefail -c "ls -t ${dir}/*owners_1_pets_1_edit.appmap.json | head -1"
   assert_success

--- a/agent/test/petclinic-shared/static-resources.bash
+++ b/agent/test/petclinic-shared/static-resources.bash
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+test_requests_for_nonstatic_resources_are_recorded_by_default() {
+  run _curl -XGET "${WS_URL}/owners/1/pets/1/edit"
+  assert_success 
+  local dir="${FIXTURE_DIR}/target/tmp/appmap/request_recording"
+  
+  wait_for_glob "${dir}/*owners_1_pets_1_edit.appmap.json"
+  run bash -c "compgen -G ${dir}/*owners_1_pets_1_edit.appmap.json"
+  assert_success
+
+  output="$(<${output})"
+  assert_json_eq '.events[] | .http_server_request | .path_info' '/owners/1/pets/1/edit' 
+}
+
+test_request_for_static_resources_dont_generate_recordings() {
+  run _curl -XGET "${WS_URL}/resources/css/petclinic.css"
+  assert_success
+
+  # After we've made the request that shouldn't generate a recording, make
+  # another that should.
+  run _curl -XGET "${WS_URL}/owners/1/pets/1/edit"
+  assert_success 
+  local dir="${FIXTURE_DIR}/target/tmp/appmap/request_recording"
+  
+  wait_for_glob "${dir}/*owners_1_pets_1_edit.appmap.json"
+  run bash -c "compgen -G ${dir}/*owners_1_pets_1_edit.appmap.json"
+  assert_success
+
+  # Now that that's done, make sure there's no recording for the static
+  # resource. compen -G returns 1 if asked to find a glob that has no matches, 2
+  # if it's invoked incorrectly.
+  run bash -c "compgen -G ${dir}/*resources_css_petclinic_css.appmap.json"
+  assert_failure 1
+}

--- a/agent/test/petclinic/petclinic-no-requests.bats
+++ b/agent/test/petclinic/petclinic-no-requests.bats
@@ -13,7 +13,7 @@ load '../helper'
 setup_file() {
   start_petclinic -Dappmap.recording.requests=false >&3
 
-  rm -rf build/fixtures/spring-petclinic/tmp
+  export FIXTURE_DIR="build/fixtures/spring-petclinic"
 }
 
 teardown_file() {
@@ -23,7 +23,7 @@ teardown_file() {
 @test "the user can disable request recording" {
   run _curl -XGET "${WS_URL}/owners/1/pets/1/edit"
   assert_success 
-  local dir='build/fixtures/spring-petclinic/target'
+  local dir="${FIXTURE_DIR}/target"
 
   # sanity check
   assert [ -d ${dir} ]

--- a/agent/test/petclinic/petclinic-no-requests.bats
+++ b/agent/test/petclinic/petclinic-no-requests.bats
@@ -20,6 +20,10 @@ teardown_file() {
   stop_ws
 }
 
+setup() {
+  rm -rf "${FIXTURE_DIR}/target/tmp/appmap"
+}
+
 @test "the user can disable request recording" {
   run _curl -XGET "${WS_URL}/owners/1/pets/1/edit"
   assert_success 

--- a/agent/test/petclinic/petclinic.bats
+++ b/agent/test/petclinic/petclinic.bats
@@ -10,6 +10,8 @@ load '../../build/bats/bats-support/load'
 load '../../build/bats/bats-assert/load'
 load '../helper'
 
+load '../petclinic-shared/static-resources.bash'
+
 setup_file() {
   start_petclinic >&3
   export FIXTURE_DIR="build/fixtures/spring-petclinic"
@@ -215,15 +217,10 @@ ownerId'
   refute_output --partial 'NaN'
 }
 
-@test "requests are recorded by default" {
-  run _curl -XGET "${WS_URL}/owners/1/pets/1/edit"
-  assert_success 
-  local dir='build/fixtures/spring-petclinic/target/tmp/appmap/request_recording'
-  
-  wait_for_glob "${dir}/*owners_1_pets_1_edit.appmap.json"
-  run bash -c "compgen -G ${dir}/*owners_1_pets_1_edit.appmap.json"
-  assert_success
+@test "requests for non-static resources are recorded by default" {
+  test_requests_for_nonstatic_resources_are_recorded_by_default
+}
 
-  output="$(<${output})"
-  assert_json_eq '.events[] | .http_server_request | .path_info' '/owners/1/pets/1/edit' 
+@test "request for static resources don't generate recordings" {
+  test_request_for_static_resources_dont_generate_recordings
 }

--- a/agent/test/spark/spark.bats
+++ b/agent/test/spark/spark.bats
@@ -28,7 +28,6 @@ setup() {
 
 @test "Spark remote recording works" {
   run _curl -sXGET "${WS_URL}/_appmap/record"
-
   assert_success
   assert_json_eq '.enabled' 'false'
 


### PR DESCRIPTION
When running a Spring app, don't generate request recordings for static
resources.

Fixes #203 .