### PR TITLE
Don't read the servlet's InputStream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
   source "$HOME/.asdf/asdf.sh"
   asdf update
   asdf plugin update --all
+  nvm install lts/*
 
 jobs:
   include:
@@ -71,7 +72,6 @@ script:
   ./bin/test
 
 before_deploy:
-  - nvm install lts/*
   - |
     npm i -g \
         semantic-release \

--- a/agent/bin/test_install
+++ b/agent/bin/test_install
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 fixture_dir=$PWD/build/fixtures
 mkdir -p build/fixtures

--- a/agent/src/main/java/com/appland/appmap/process/hooks/SpringBoot.java
+++ b/agent/src/main/java/com/appland/appmap/process/hooks/SpringBoot.java
@@ -58,11 +58,6 @@ public class SpringBoot {
   @ArgumentArray
   @HookClass(value = "org.springframework.boot.SpringApplication")
   public static void applyInitializers(Event event, Object receiver, Object[] args) {
-    if (!Properties.RecordingRequests) {
-      logger.debug("request recording disabled");
-      return;
-    }
-
     logger.trace("receiver: {}", receiver);
 
     ApplicationContext ctx = new ApplicationContext(args[0]);
@@ -74,7 +69,9 @@ public class SpringBoot {
 
       if (remoteRecordingFilter != null && servletListener != null) {
         beanFactory.registerSingleton(LISTENER_BEAN + ".remoteRecordingFilter", remoteRecordingFilter);
-        beanFactory.registerSingleton(LISTENER_BEAN, servletListener);
+        if (Properties.RecordingRequests) {
+          beanFactory.registerSingleton(LISTENER_BEAN, servletListener);
+        }
         logger.trace("registered beans");
       } else {
         logger.trace("a bean is null, remoteRecordingFilter: {} servletListener: {}", remoteRecordingFilter,

--- a/agent/src/main/java/com/appland/appmap/process/hooks/SpringBoot.java
+++ b/agent/src/main/java/com/appland/appmap/process/hooks/SpringBoot.java
@@ -16,22 +16,29 @@ import com.appland.appmap.reflect.ReflectiveType;
 import com.appland.appmap.transform.annotations.ArgumentArray;
 import com.appland.appmap.transform.annotations.ExcludeReceiver;
 import com.appland.appmap.transform.annotations.HookClass;
+import com.appland.appmap.transform.annotations.MethodEvent;
 public class SpringBoot {
+  private static final String SERVLET_CONTEXT_INITIALIZED = "com.appland.appmap.ServletContextInitialized";
   private static final String LISTENER_BEAN = "appmap.listener";
   private static final TaggedLogger logger = AppMapConfig.getLogger(null);
 
   static class ApplicationContext extends ReflectiveType {
     private static String GET_BEAN_FACTORY = "getBeanFactory";
+    private static String GET_SERVLET_CONTEXT = "getServletContext";
 
     ApplicationContext(Object self) {
       super(self);
-      addMethods(GET_BEAN_FACTORY);
+      addMethods(GET_BEAN_FACTORY, GET_SERVLET_CONTEXT);
     }
 
     public ConfigurableListableBeanFactory getBeanFactory() {
       return new ConfigurableListableBeanFactory(invokeObjectMethod(GET_BEAN_FACTORY));
     }
 
+    public ServletContext getServletContext() {
+      Object ret = invokeObjectMethod(GET_SERVLET_CONTEXT);
+      return ret != null ? new ServletContext(ret) : null;
+    }
   }
 
   static class ConfigurableListableBeanFactory extends ReflectiveType {
@@ -56,13 +63,20 @@ public class SpringBoot {
   // applyInitializers is part of the documented interface of SpringApplication,
   // and has been available since at least v2.7. Should be ok to depend on it.
   @ArgumentArray
-  @HookClass(value = "org.springframework.boot.SpringApplication")
-  public static void applyInitializers(Event event, Object receiver, Object[] args) {
-    logger.trace("receiver: {}", receiver);
+  @HookClass(value = "org.springframework.boot.SpringApplication", methodEvent = MethodEvent.METHOD_RETURN)
+  public static void applyInitializers(Event event, Object receiver, Object ret, Object[] args) {
+    ApplicationContext appCtx = new ApplicationContext(args[0]);
+    logger.trace(new Exception(), "ctx: {}", appCtx);
+    ServletContext servletCtx = appCtx.getServletContext();
+    if (servletCtx != null) {
+      Object initializedAttr = servletCtx.getAttribute(SERVLET_CONTEXT_INITIALIZED);
+      if (initializedAttr != null && ((Boolean) initializedAttr).booleanValue()) {
+        logger.trace("servlet context initialized");
+        return;
+      }
+    }
 
-    ApplicationContext ctx = new ApplicationContext(args[0]);
-    logger.trace(new Exception(), "ctx: {}", ctx);
-    ConfigurableListableBeanFactory beanFactory = ctx.getBeanFactory();
+    ConfigurableListableBeanFactory beanFactory = appCtx.getBeanFactory();
     if (beanFactory.getSingleton(LISTENER_BEAN) == null) {
       Object remoteRecordingFilter = RemoteRecordingFilter.build();
       Object servletListener = ServletListener.build();
@@ -70,6 +84,7 @@ public class SpringBoot {
       if (remoteRecordingFilter != null && servletListener != null) {
         beanFactory.registerSingleton(LISTENER_BEAN + ".remoteRecordingFilter", remoteRecordingFilter);
         if (Properties.RecordingRequests) {
+          logger.trace("registering servlet listener as singleton");
           beanFactory.registerSingleton(LISTENER_BEAN, servletListener);
         }
         logger.trace("registered beans");
@@ -89,7 +104,10 @@ public class SpringBoot {
   @HookClass(value = "org.springframework.web.SpringServletContainerInitializer")
   public static void onStartup(Event event, Object[] args) {
     ServletContext ctx = new ServletContext(args[1]);
+    logger.trace(new Exception(), "ctx: {}", ctx);
+
     if (Properties.RecordingRequests) {
+      logger.trace("adding listener to sevlet context");
       ctx.addListener(ServletListener.build());
     } else {
       logger.debug("request recording disabled");
@@ -98,6 +116,8 @@ public class SpringBoot {
     ServletContext.FilterRegistration fr = ctx.addFilter("com.appland.appmap.RemoteRecordingFilter",
         RemoteRecordingFilter.build());
     fr.addMappingForUrlPatterns(requestEnumSet(), true, "/_appmap/record");
+
+    ctx.setAttribute(SERVLET_CONTEXT_INITIALIZED, Boolean.TRUE);
   }
 
     @SuppressWarnings("unchecked")

--- a/agent/src/test/fixture/petclinic/ShowAvailable.java
+++ b/agent/src/test/fixture/petclinic/ShowAvailable.java
@@ -1,0 +1,34 @@
+package org.springframework.samples.petclinic.web;
+
+import java.io.IOException;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * ShowAvailable is a simple Spring Controller that simply returns the number
+ * of bytes available in the request's InputStream.
+ */
+@RestController
+public class ShowAvailable {
+  private static class Result {
+    private final int available;
+
+    public Result(int available) {
+      this.available = available;
+    }
+
+    public String getAvailable() {
+      return Integer.toString(available);
+    }
+  }
+
+  @PostMapping("/showavailable")
+  public String doPost(@RequestBody String body) throws Exception {
+    return new ObjectMapper().writeValueAsString(new Result(body.length()));
+  }
+
+}

--- a/agent/test/helper.bash
+++ b/agent/test/helper.bash
@@ -133,7 +133,7 @@ start_petclinic() {
   AGENT_JAR="$(find_agent_jar)"
 
   pushd build/fixtures/spring-petclinic >/dev/null
-  ./mvnw --quiet -DskipTests -Dcheckstyle.skip=true \
+  ./mvnw --quiet -DskipTests -Dcheckstyle.skip=true -Dspring-javaformat.skip=true \
     -Dspring-boot.run.agents=$AGENT_JAR -Dspring-boot.run.jvmArguments="-Dappmap.config.file=$WD/test/petclinic/appmap.yml $jvmargs" \
     spring-boot:run &>$LOG  3>&- &
   popd >/dev/null
@@ -158,7 +158,7 @@ start_petclinic_fw() {
   AGENT_JAR="$(find_agent_jar)"
 
   pushd build/fixtures/spring-framework-petclinic >/dev/null
-  ./mvnw --quiet -DskipTests -Dcheckstyle.skip=true \
+  ./mvnw --quiet -DskipTests -Dcheckstyle.skip=true -Dspring-javaformat.skip=true \
     -Djetty.deployMode=FORK -Djetty.jvmArgs="-javaagent:$AGENT_JAR -Dappmap.config.file=$WD/test/petclinic/appmap.yml" \
     jetty:run-war &>$LOG  3>&- &
   local mvn_pid=$!

--- a/agent/test/http_client/http_client.bats
+++ b/agent/test/http_client/http_client.bats
@@ -8,7 +8,7 @@ setup_file() {
   cp test/http_client/NoContentController.java build/fixtures/spring-petclinic/src/main/java/org/springframework/samples/petclinic/system/.
   start_petclinic >&3
 
-  pushd test/http_client
+  pushd test/http_client >/dev/null
 }
 
 teardown_file() {

--- a/agent/test/httpcore/test
+++ b/agent/test/httpcore/test
@@ -8,7 +8,7 @@ SERVER_PORT=9090
 WS_URL="http://localhost:${SERVER_PORT}"
 
 start_server() {
-  pushd test/httpcore
+  pushd test/httpcore >/dev/null
     
   printf 'getting set up' 1>&2
   ./gradlew run --args "${SERVER_PORT}"   &> $LOG &

--- a/agent/test/petclinic-fw/petclinic-fw.bats
+++ b/agent/test/petclinic-fw/petclinic-fw.bats
@@ -5,10 +5,13 @@ load '../../build/bats/bats-assert/load'
 load '../helper'
 
 load '../petclinic-shared/static-resources.bash'
+load '../petclinic-shared/message-params.bash'
 
 setup_file() {
-  start_petclinic_fw >&3
   export FIXTURE_DIR=build/fixtures/spring-framework-petclinic
+  _setup_params
+
+  start_petclinic_fw >&3
 }
 
 teardown_file() {
@@ -38,9 +41,17 @@ setup() {
 }
 
 @test "requests for non-static resources are recorded by default" {
-  test_requests_for_nonstatic_resources_are_recorded_by_default
+  _test_requests_for_nonstatic_resources_are_recorded_by_default
 }
 
 @test "request for static resources don't generate recordings" {
-  test_request_for_static_resources_dont_generate_recordings
+  _test_request_for_static_resources_dont_generate_recordings
+}
+
+@test "form data is recorded as message parameters" {
+  _test_form_data_is_recorded_as_message_parameters
+}
+
+@test "the agent doesn't exhaust the InputStream" {
+  _test_the_agent_doesnt_exhaust_theInputStream
 }

--- a/agent/test/petclinic-shared/static-resources.bash
+++ b/agent/test/petclinic-shared/static-resources.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-test_requests_for_nonstatic_resources_are_recorded_by_default() {
+_test_requests_for_nonstatic_resources_are_recorded_by_default() {
   run _curl -XGET "${WS_URL}/owners/1/pets/1/edit"
   assert_success 
   local dir="${FIXTURE_DIR}/target/tmp/appmap/request_recording"
@@ -13,7 +13,7 @@ test_requests_for_nonstatic_resources_are_recorded_by_default() {
   assert_json_eq '.events[] | .http_server_request | .path_info' '/owners/1/pets/1/edit' 
 }
 
-test_request_for_static_resources_dont_generate_recordings() {
+_test_request_for_static_resources_dont_generate_recordings() {
   run _curl -XGET "${WS_URL}/resources/css/petclinic.css"
   assert_success
 

--- a/agent/test/petclinic/petclinic-tests.bats
+++ b/agent/test/petclinic/petclinic-tests.bats
@@ -26,7 +26,8 @@ run_petclinic_test() {
   local cfg="${1:-appmap.yml}"
 
   run ./mvnw \
-    -DargLine="@{argLine} -Dcheckstyle.skip=true -javaagent:${AGENT_JAR} -Dappmap.config.file=../../../test/petclinic/${cfg} -Dappmap.debug  -Dappmap.debug.file=appmap.log" \
+    -Dcheckstyle.skip=true -Dspring-javaformat.skip=true \
+    -DargLine="@{argLine} -javaagent:${AGENT_JAR} -Dappmap.config.file=../../../test/petclinic/${cfg} -Dappmap.debug  -Dappmap.debug.file=appmap.log" \
     test -Dtest="${TEST_NAME}#testOwnerDetails"
   assert_success
 }


### PR DESCRIPTION
The agent should not cause the body of a request to be read, e.g. by
getting the parameter map before HttpServlet.service is invoked.  These
changes avoid this by calling getParameterMap after HttpServlet.service
returns.

Also fixes a couple of other bugs I noticed while working on this one.

Fixes #199 .