### PR TITLE
fix: handle unset appmap.output.directory

### DIFF
--- a/agent/test/spark/app/appmap.yml
+++ b/agent/test/spark/app/appmap.yml
@@ -1,4 +1,4 @@
 name: sparkexample
-appmap_dir: app/build/tmp/appmap
+appmap_dir: build/tmp/appmap
 packages:
 - path: com.appland.appmap.sparkexample


### PR DESCRIPTION
Make sure Properties.OutputDirectory is set correctly when the config contains appmap_dir and system property appmap.output.directory is unset. Prior to these changes, OutputDirectory was getting set to a default value, rather than what the config contained.

Fixes #204 .