### PR TITLE
feat: make tmp/appmap the default output directory

### DIFF
--- a/agent/src/main/java/com/appland/appmap/config/AppMapConfig.java
+++ b/agent/src/main/java/com/appland/appmap/config/AppMapConfig.java
@@ -11,7 +11,6 @@ import java.io.StringWriter;
 import java.nio.file.FileSystem;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
@@ -300,47 +299,6 @@ public class AppMapConfig {
   }
 
   private static Path findDefaultOutputDirectory(FileSystem fs) {
-    long buildGradleLastModified = 0;
-    long pomXmlLastModified = 0;
-    try {
-      buildGradleLastModified = Files.getLastModifiedTime(fs.getPath("build.gradle")).toMillis();
-    } catch (NoSuchFileException e) {
-      // Can't use logger yet, and this may happen regularly, so just swallow
-      // it.
-    } catch (IOException e) {
-      // This shouldn't happen, though
-      e.printStackTrace();
-    }
-    try {
-      pomXmlLastModified = Files.getLastModifiedTime(fs.getPath("pom.xml")).toMillis();
-    } catch (NoSuchFileException e) {
-      // noop, as above
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
-
-    // Neither exists, use tmp
-    if (buildGradleLastModified == 0 && pomXmlLastModified == 0) {
-      return fs.getPath("tmp/appmap");
-    }
-
-    // Both exist, use newer
-    String gradleDir = "build/tmp/appmap";
-    String mavenDir = "target/tmp/appmap";
-    if (buildGradleLastModified != 0 && pomXmlLastModified != 0) {
-      if (buildGradleLastModified > pomXmlLastModified) {
-        return fs.getPath(gradleDir);
-      } else {
-        return fs.getPath(mavenDir);
-      }
-    }
-
-    // Might be Gradle
-    if (buildGradleLastModified > 0) {
-      return fs.getPath(gradleDir);
-    }
-
-    // Must be Maven
-    return fs.getPath(mavenDir);
+    return fs.getPath("tmp/appmap");
   }
 }

--- a/agent/src/test/java/com/appland/appmap/config/OutputDirectoryTest.java
+++ b/agent/src/test/java/com/appland/appmap/config/OutputDirectoryTest.java
@@ -130,64 +130,9 @@ public class OutputDirectoryTest {
       assertEquals(configDir, AppMapConfig.get().getAppmapDir().toString());
     }
 
-    @Nested
-    @DisplayName("When build.gradle exists")
-    class WhenGradleConfigExists {
-      @BeforeEach
-      void createGradleConfig() throws Exception {
-        Files.createFile(appDir.resolve("build.gradle"));
-      }
-
-      @Test
-      @DisplayName("When pom.xml exists and is newer")
-      void mavenConfigExists() throws Exception {
-        Thread.sleep(10); // to ensure pom.xml will be newer
-        Files.createFile(appDir.resolve("pom.xml"));
-        AppMapConfig.initialize(fs);
-
-        assertEquals("target/tmp/appmap", AppMapConfig.get().getAppmapDir().toString());
-      }
-
-      @Test
-      @DisplayName("When pom.xml does not exist")
-      void mavenConfigDoesNotExist() throws Exception {
-        AppMapConfig.initialize(fs);
-
-        assertEquals("build/tmp/appmap", AppMapConfig.get().getAppmapDir().toString());
-      }
-    }
-
-    @Nested
-    @DisplayName("When pom.xml exists")
-    class WhenMavenConfigExists {
-
-      @BeforeEach
-      void createMavenConfig() throws Exception {
-        Files.createFile(appDir.resolve("pom.xml"));
-      }
-
-      @Test
-      @DisplayName("When build.gradle exists and is newer")
-      void gradleConfigExists() throws Exception {
-        Thread.sleep(10); // to ensure build.gradle will be newer
-        Files.createFile(appDir.resolve("build.gradle"));
-        AppMapConfig.initialize(fs);
-
-        assertEquals("build/tmp/appmap", AppMapConfig.get().getAppmapDir().toString());
-      }
-
-      @Test
-      @DisplayName("When build.gradle does not exist")
-      void gradleConfigDoesNotExist() throws Exception {
-        AppMapConfig.initialize(fs);
-
-        assertEquals("target/tmp/appmap", AppMapConfig.get().getAppmapDir().toString());
-      }
-    }
-
     @Test
-    @DisplayName("When neither build.gradle nor pom.xml exists")
-    void noBuildConfigExists() throws Exception {
+    @DisplayName("the default is used")
+    void defaultChosen() throws Exception {
       AppMapConfig.initialize(fs);
 
       assertEquals("tmp/appmap", AppMapConfig.get().getAppmapDir().toString());

--- a/agent/test/jdbc/jdbc.bats
+++ b/agent/test/jdbc/jdbc.bats
@@ -12,7 +12,7 @@ setup_file() {
 @test "it works" {
   ./gradlew -is test 
 
-  output="$(<build/tmp/appmap/junit/com_example_accessingdatajpa_CustomerRepositoryTests_testFindFromBogusTable.appmap.json)"
+  output="$(<./tmp/appmap/junit/com_example_accessingdatajpa_CustomerRepositoryTests_testFindFromBogusTable.appmap.json)"
   assert_json_eq '.events | length' 4
   assert_json_eq '.events[2].exceptions | length' 1
   assert_json_eq '.events[2].exceptions[0].class' org.h2.jdbc.JdbcSQLSyntaxErrorException

--- a/agent/test/petclinic-fw/petclinic-fw.bats
+++ b/agent/test/petclinic-fw/petclinic-fw.bats
@@ -19,7 +19,7 @@ teardown_file() {
 }
 
 setup() {
-  rm -rf "${FIXTURE_DIR}/target/tmp/appmap"
+  rm -rf "${FIXTURE_DIR}/tmp/appmap"
 }
 
 @test "remote recording works" { 

--- a/agent/test/petclinic-shared/static-resources.bash
+++ b/agent/test/petclinic-shared/static-resources.bash
@@ -3,7 +3,7 @@
 _test_requests_for_nonstatic_resources_are_recorded_by_default() {
   run _curl -XGET "${WS_URL}/owners/1/pets/1/edit"
   assert_success 
-  local dir="${FIXTURE_DIR}/target/tmp/appmap/request_recording"
+  local dir="${FIXTURE_DIR}/tmp/appmap/request_recording"
   
   wait_for_glob "${dir}/*owners_1_pets_1_edit.appmap.json"
   run bash -c "compgen -G ${dir}/*owners_1_pets_1_edit.appmap.json"
@@ -21,7 +21,7 @@ _test_request_for_static_resources_dont_generate_recordings() {
   # another that should.
   run _curl -XGET "${WS_URL}/owners/1/pets/1/edit"
   assert_success 
-  local dir="${FIXTURE_DIR}/target/tmp/appmap/request_recording"
+  local dir="${FIXTURE_DIR}/tmp/appmap/request_recording"
   
   wait_for_glob "${dir}/*owners_1_pets_1_edit.appmap.json"
   run bash -c "compgen -G ${dir}/*owners_1_pets_1_edit.appmap.json"

--- a/agent/test/petclinic/petclinic-tests.bats
+++ b/agent/test/petclinic/petclinic-tests.bats
@@ -34,7 +34,7 @@ run_petclinic_test() {
 
 @test "hooked functions are ordered correctly" {
   run_petclinic_test
-  run cat ./target/tmp/appmap/junit/org_springframework_samples_petclinic_${TEST_NAME}_testOwnerDetails.appmap.json
+  run cat ./tmp/appmap/junit/org_springframework_samples_petclinic_${TEST_NAME}_testOwnerDetails.appmap.json
   assert_success
 
   # Thread 1 is the test runner's main thread. Check to make sure that parent_id
@@ -54,7 +54,7 @@ run_petclinic_test() {
 @test "log methods are labeled" {
   run_petclinic_test appmap-labels.yml
 
-  run cat ./target/tmp/appmap/junit/org_springframework_samples_petclinic_${TEST_NAME}_testOwnerDetails.appmap.json
+  run cat ./tmp/appmap/junit/org_springframework_samples_petclinic_${TEST_NAME}_testOwnerDetails.appmap.json
 
   assert_json_eq '.classMap[0] | recurse(.children[]?) | select(.type? == "function" and .name? == "info").labels[0]' 'log'
 }

--- a/agent/test/petclinic/petclinic.bats
+++ b/agent/test/petclinic/petclinic.bats
@@ -25,7 +25,7 @@ teardown_file() {
 }
 
 setup() {
-  rm -rf "${FIXTURE_DIR}/target/tmp/appmap"
+  rm -rf "${FIXTURE_DIR}/tmp/appmap"
 }
 
 @test "the recording status reports disabled when not recording" {

--- a/agent/test/spark/app/appmap.yml
+++ b/agent/test/spark/app/appmap.yml
@@ -1,4 +1,4 @@
 name: sparkexample
-appmap_dir: build/tmp/appmap
+appmap_dir: tmp/appmap
 packages:
 - path: com.appland.appmap.sparkexample

--- a/agent/test/spark/spark.bats
+++ b/agent/test/spark/spark.bats
@@ -2,7 +2,7 @@ load '../../build/bats/bats-support/load'
 load '../../build/bats/bats-assert/load'
 load '../helper'
 
-recording_dir="app/build/tmp/appmap/request_recording"
+recording_dir="app/tmp/appmap/request_recording"
 
 setup_file() {
   export WS_SCHEME="http" WS_HOST="localhost" WS_PORT="8080"


### PR DESCRIPTION
Undo the recent change that made the default output directory depend on the project's build tool. It's always tmp/appmap now.

Fixes #210.