### PR TITLE
fix: set request recording type correctly

### DIFF
--- a/agent/src/main/java/com/appland/appmap/process/hooks/RequestRecording.java
+++ b/agent/src/main/java/com/appland/appmap/process/hooks/RequestRecording.java
@@ -28,7 +28,7 @@ public class RequestRecording {
       return;
     }
 
-    Recorder.Metadata metadata = new Recorder.Metadata("request_recording", "request");
+    Recorder.Metadata metadata = new Recorder.Metadata("request_recording", "requests");
 
     RecordingSession recordingSession = new RecordingSession(metadata);
 

--- a/agent/test/petclinic-shared/static-resources.bash
+++ b/agent/test/petclinic-shared/static-resources.bash
@@ -11,6 +11,7 @@ _test_requests_for_nonstatic_resources_are_recorded_by_default() {
 
   output="$(<${output})"
   assert_json_eq '.events[] | .http_server_request | .path_info' '/owners/1/pets/1/edit' 
+  assert_json_eq '.metadata.recorder.type' 'requests'
 }
 
 _test_request_for_static_resources_dont_generate_recordings() {

--- a/agent/test/petclinic/petclinic-tests.bats
+++ b/agent/test/petclinic/petclinic-tests.bats
@@ -34,7 +34,7 @@ run_petclinic_test() {
   run ./mvnw \
     -Dcheckstyle.skip=true -Dspring-javaformat.skip=true \
     -DargLine="@{argLine} -javaagent:${AGENT_JAR} -Dappmap.config.file=../../../test/petclinic/${cfg} -Dappmap.debug  -Dappmap.debug.file=appmap.log" \
-    test -Dtest="${TEST_NAME}#testOwnerDetails"
+    test -Dtest="${TEST_NAME}"
   assert_success
 }
 


### PR DESCRIPTION
The type of a request recording should be `requests`, not `request`.

Fixes #223.