### PR TITLE
fix: decrease logging about missing classes

### DIFF
--- a/agent/src/main/java/com/appland/appmap/output/v1/Parameters.java
+++ b/agent/src/main/java/com/appland/appmap/output/v1/Parameters.java
@@ -52,9 +52,23 @@ public class Parameters implements Iterable<Value> {
     try {
       paramTypes = behavior.getParameterTypes();
     } catch (NotFoundException e) {
-      throw new NoSourceAvailableException(
-        String.format("Failed to get parameter types for %s: %s",
-                      fqn, e.getMessage()));
+      //@formatter:off
+      // getParameterTypes throws NotFoundException when it can't find a class
+      // definition for the type of one of the parameters. Given that:
+      //
+      //   * the method represented by this behavior was loaded from one of the
+      //     app's classes (and so originally compiled successfully)
+      //
+      //   * the JVM resolves the classes for a method's parameters before
+      //     loading the method itself
+      //
+      // this failure can only happen if we're trying to instrument a method
+      // that can never be called.
+      //
+      // Log a message and bail.
+      //@formatter:on
+      logger.debug(e, "Failed to get parameter types for {}", fqn);
+      return;
     }
 
     CodeAttribute codeAttribute = methodInfo.getCodeAttribute();

--- a/agent/src/main/java/com/appland/appmap/transform/annotations/Hook.java
+++ b/agent/src/main/java/com/appland/appmap/transform/annotations/Hook.java
@@ -286,8 +286,7 @@ public class Hook {
       try {
         returnType = ((CtMethod) behavior).getReturnType();
       } catch (NotFoundException e) {
-        Logger.println("warning - unknown return type");
-        Logger.println(e);
+        logger.debug(e, "unknown return type");
       }
     }
     return returnType;

--- a/agent/src/main/java/com/appland/appmap/transform/annotations/SourceMethodSystem.java
+++ b/agent/src/main/java/com/appland/appmap/transform/annotations/SourceMethodSystem.java
@@ -1,16 +1,21 @@
 package com.appland.appmap.transform.annotations;
 
 import java.util.Map;
+
+import org.tinylog.TaggedLogger;
+
+import com.appland.appmap.config.AppMapConfig;
 import com.appland.appmap.output.v1.Parameters;
 import com.appland.appmap.output.v1.Value;
-import com.appland.appmap.util.Logger;
 
-import javassist.CtClass;
 import javassist.CtBehavior;
+import javassist.CtClass;
 import javassist.CtMethod;
 import javassist.NotFoundException;
 
 public abstract class SourceMethodSystem extends BaseSystem {
+  private static final TaggedLogger logger = AppMapConfig.getLogger(null);
+
   public static final String EVENT_TOKEN = "$evt";
 
   private String hookClass;
@@ -62,8 +67,10 @@ public abstract class SourceMethodSystem extends BaseSystem {
 
           runtimeParameters.add(returnValue);
         } catch (NotFoundException e) {
-          Logger.println("warning - unknown return type");
-          Logger.println(e);
+          // getReturnType throws a NotFoundException when the class of the
+          // returned value can't be found. See the note in the Parameters
+          // constructor describing why we should be able to ignore this.
+          logger.debug(e, "unknown return type");
         }
       }
     } else if (this.methodEvent == MethodEvent.METHOD_EXCEPTION) {


### PR DESCRIPTION
There are times when classes can be expected to be missing. See the comment in Parameters.java for further details.

Fixes #241 .