### PR TITLE
support JUnit 5 test methods with parameters

### DIFF
--- a/agent/src/main/java/com/appland/appmap/process/hooks/test/TestSupport.java
+++ b/agent/src/main/java/com/appland/appmap/process/hooks/test/TestSupport.java
@@ -1,15 +1,21 @@
 package com.appland.appmap.process.hooks.test;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
+import org.tinylog.TaggedLogger;
+
+import com.appland.appmap.config.AppMapConfig;
 import com.appland.appmap.output.v1.Event;
 import com.appland.appmap.process.hooks.RecordingSupport;
 import com.appland.appmap.process.hooks.RecordingSupport.TestDetails;
 import com.appland.appmap.record.Recorder;
 import com.appland.appmap.transform.annotations.AnnotationUtil;
-import com.appland.appmap.util.ClassUtil;
 
 class TestSupport {
+  private static final TaggedLogger logger = AppMapConfig.getLogger(null);
+
   static final String TEST_RECORDER_TYPE = "tests";
 
   static void startRecording(Event event, Recorder.Metadata metadata) {
@@ -24,6 +30,8 @@ class TestSupport {
     // stack[0] is the call to getStackTrace, stack[1] is the call to
     // startRecording, stack[2] is the call to the hook method, so stack[3] is
     // the call to the test method:
+    logger.trace("stack: {}", () -> Arrays.stream(stack).map(StackTraceElement::toString)
+        .collect(Collectors.joining("\n")));
     if (!isRecordingEnabled(stack[3])) {
       return;
     }
@@ -32,10 +40,43 @@ class TestSupport {
   }
 
   private static boolean isRecordingEnabled(StackTraceElement ste) {
-    Method testMethod = ClassUtil.findMethod(ste);
+    Method testMethod = findTestMethod(ste);
     String noAppMap = "com.appland.appmap.annotation.NoAppMap";
     boolean methodAnnotated = AnnotationUtil.hasAnnotation(noAppMap, testMethod);
     boolean classAnnotated = AnnotationUtil.hasAnnotation(noAppMap, testMethod.getDeclaringClass());
     return !methodAnnotated && !classAnnotated;
+  }
+
+  /**
+   * Find the test method that corresponds to the method named in the given StackTraceElement.
+   *
+   * This is complicated a little by the fact that method names in Java classes aren't unique, so
+   * there may be more than one that matches. It's not common to have overloaded test methods,
+   * though, so we'll just use the first one we find (and issue a warning if there are more).
+   *
+   * @param ste
+   * @return
+   */
+  private static Method findTestMethod(StackTraceElement ste) {
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    try {
+      String className = ste.getClassName();
+      String methodName = ste.getMethodName();
+
+      Class<?> cls = Class.forName(className, true, cl);
+      Method[] methods = Arrays.stream(cls.getDeclaredMethods())
+          .filter(m -> m.getName().equals(methodName)).toArray(Method[]::new);
+      if (methods.length == 0) {
+        throw new InternalError("No method named " + methodName + " in " + className);
+      }
+      Method method = methods[0];
+      if (methods.length > 1) {
+        logger.warn("Found {} methods named {} in {}, using {}", methods.length, methodName,
+            className, method.getName());
+      }
+      return method;
+    } catch (SecurityException | ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/agent/src/main/java/com/appland/appmap/util/ClassUtil.java
+++ b/agent/src/main/java/com/appland/appmap/util/ClassUtil.java
@@ -2,7 +2,6 @@ package com.appland.appmap.util;
 
 import static org.apache.commons.lang3.StringUtils.stripAll;
 
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -160,15 +159,5 @@ public class ClassUtil {
   @SuppressWarnings("all")
   public static EnumSet<?> enumSetOf(Class<?> enumClass, String valueName) {
     return EnumSet.of((Enum) enumValueOf(enumClass.asSubclass(Enum.class), valueName));
-  }
-
-  public static Method findMethod(StackTraceElement ste) {
-    try {
-      Class<?> cls = safeClassForName(Thread.currentThread().getContextClassLoader(), ste.getClassName());
-      Class<?>[] args = {};
-      return cls.getDeclaredMethod(ste.getMethodName(), args);
-    } catch (NoSuchMethodException | SecurityException e) {
-      throw new RuntimeException(e);
-    }
   }
 }

--- a/agent/src/test/fixture/petclinic/src/test/java/org/springframework/samples/petclinic/JUnit5Tests.java
+++ b/agent/src/test/fixture/petclinic/src/test/java/org/springframework/samples/petclinic/JUnit5Tests.java
@@ -2,16 +2,21 @@ package org.springframework.samples.petclinic;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.appland.appmap.annotation.NoAppMap;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.appland.appmap.annotation.NoAppMap;
 
 public class JUnit5Tests {
   @Test
   public void testItPasses() {
     System.err.println("passing test");
-    
+
     assertTrue(true);
   }
 
@@ -41,4 +46,8 @@ public class JUnit5Tests {
     }
   }
 
+  @Test
+  public void testWithParameter(@TempDir Path tempDir) throws IOException {
+    assertTrue(Files.exists(tempDir));
+  }
 }

--- a/agent/test/petclinic/petclinic-tests.bats
+++ b/agent/test/petclinic/petclinic-tests.bats
@@ -91,7 +91,7 @@ run_petclinic_test() {
 
   assert_json_eq '.metadata.test_status' 'failed'
   assert_json_eq '.metadata.test_failure.message' 'expected: <true> but was: <false>'
-  assert_json_eq '.metadata.test_failure.location' 'src/test/java/org/springframework/samples/petclinic/JUnit5Tests.java:22'
+  assert_json_eq '.metadata.test_failure.location' 'src/test/java/org/springframework/samples/petclinic/JUnit5Tests.java:27'
 }  
 
 @test "NoAppMap on method disables test recording" {
@@ -108,4 +108,12 @@ run_petclinic_test() {
 
   run test \! -f ./tmp/appmap/junit/org_springframework_samples_petclinic_JUnit5Tests_testAnnotatedMethodNotRecorded.appmap.json
   assert_success
+}
+
+@test "test with extension works" {
+  run_petclinic_test "JUnit5Tests#testWithParameter"
+  assert_success
+
+  run cat ./tmp/appmap/junit/org_springframework_samples_petclinic_JUnit5Tests_testWithParameter.appmap.json
+  assert_json_eq '.events[0].method_id' 'testWithParameter'
 }


### PR DESCRIPTION
Test methods in JUnit 5 can take parameters (to make use of [extensions](https://junit.org/junit5/docs/current/user-guide/#extensions)). These changes take that into account.

Fixes #240 .