### PR TITLE
Don't locate Agent jar using ProtectionDomain.getCodeSource

### DIFF
--- a/agent/src/main/java/com/appland/appmap/process/hooks/ProxyHooks.java
+++ b/agent/src/main/java/com/appland/appmap/process/hooks/ProxyHooks.java
@@ -80,7 +80,7 @@ public class ProxyHooks {
 
   void invokeReturn(Object proxy, Object ret, Object[] methodArgs) {
     logger.trace("returnHook: {}, method event: {}, ret: {}", returnHook::toString,
-        returnHook::getMethodEvent, ret::toString);
+        returnHook::getMethodEvent, () -> ret != null ? ret.toString() : "void");
     Event event = EventTemplateRegistry.get().buildReturnEvent(returnHook.getBehaviorOrdinal());
     MethodReturn.handle(event, proxy, ret, methodArgs);
   }

--- a/agent/test/classloading/app/src/main/java/com/appland/appmap/test/fixture/TestProxy.java
+++ b/agent/test/classloading/app/src/main/java/com/appland/appmap/test/fixture/TestProxy.java
@@ -52,6 +52,9 @@ public class TestProxy implements TestClass {
           Object proxy = Proxy.newProxyInstance(cl, hwClass, hwHandler);
           Method getGreeting = proxy.getClass().getMethod("getGreeting", Integer.TYPE);
           getGreeting.invoke(proxy, Integer.valueOf(1));
+
+          Method doSomething = proxy.getClass().getMethod("doSomething");
+          doSomething.invoke(proxy);
         } catch (Exception e) {
           throw new RuntimeException(e);
         }

--- a/agent/test/classloading/lib/src/main/java/com/appland/appmap/test/fixture/helloworld/HelloWorld.java
+++ b/agent/test/classloading/lib/src/main/java/com/appland/appmap/test/fixture/helloworld/HelloWorld.java
@@ -3,4 +3,6 @@ package com.appland.appmap.test.fixture.helloworld;
 
 public interface HelloWorld {
   String getGreeting(int greetingId);
+
+  void doSomething();
 }

--- a/agent/test/intellij/intellij.bats
+++ b/agent/test/intellij/intellij.bats
@@ -1,0 +1,43 @@
+load '../../build/bats/bats-support/load'
+load '../../build/bats/bats-assert/load'
+load '../helper'
+
+init_plugin() {
+    git clone --depth=1 https://github.com/applandinc/appmap-intellij-plugin.git
+}
+
+setup_file() {
+  if [[ $JAVA_VERSION != 17.* ]]; then
+    skip "needs Java 17"
+  fi
+
+  export AGENT_JAR="$(find_agent_jar)"
+
+  cd test/intellij
+  _configure_logging
+
+  if [[ ! -d appmap-intellij-plugin ]]; then
+    init_plugin
+  fi
+}
+
+setup() {
+  cd appmap-intellij-plugin
+  rm -rf tmp/appmap
+
+  ./gradlew clean
+  mkdir build
+  cp "${AGENT_JAR}" build/appmap-agent.jar
+}
+
+@test 'it works' {
+  # TODO: remove this ideVersion pin
+  run ./gradlew -PideVersion=IC-2023.3.3 :plugin-core:test --tests 'AppMapConfigFileTest.readConfigWithPath'
+  assert_success
+
+  output="$(< tmp/appmap/junit/appland_config_AppMapConfigFileTest_readConfigWithPath.appmap.json)"
+  local lengths=( $(jq '(.events | length),(.classMap | length)' <<< "${output}") )
+  # AppMap shouldn't be empty
+  assert [ ${lengths[0]} -gt 0 ]
+  assert [ ${lengths[1]} -gt 0 ]
+}


### PR DESCRIPTION
Instead of using ProtectionDomain.getCodeSource to find the agent jar,
use the ClassLoader that loaded Agent.class. The CodeSource might be
null (e.g. when testing the IntelliJ plugin), but the class loader will
always be able to say where Agent.class was loaded from.

Also, avoid an NPE when a Proxy method returns void.

Fixes #257 .
Fixes #258 .