### PR TITLE
fix: correct detection of Spark server

### DIFF
--- a/agent/src/main/java/com/appland/appmap/process/hooks/Spark.java
+++ b/agent/src/main/java/com/appland/appmap/process/hooks/Spark.java
@@ -145,11 +145,16 @@ public class Spark {
     if (!argClass.equals(jettyHandlerClass)) {
       if (argClass.equals("org.eclipse.jetty.server.handler.HandlerList")) {
         HandlerList hl = new HandlerList(handler);
-        boolean match = Arrays.stream(hl.getHandlers()).anyMatch(h -> h.getClass().getName().equals(jettyHandlerClass));
+        boolean match = Arrays.stream(hl.getHandlers())
+            .anyMatch(h -> h.getClass().getName().equals(jettyHandlerClass));
         if (!match) {
           return;
         }
       }
+
+      // If it's not either the Spark JettyHandler or a HandlerList, we're not running in a Spark
+      // server.
+      return;
     }
     HandlerWrapper server = new HandlerWrapper(receiver);
     logger.trace("handler: {}", handler);

--- a/agent/test/helper.bash
+++ b/agent/test/helper.bash
@@ -178,7 +178,7 @@ start_petclinic() {
   AGENT_JAR="$(find_agent_jar)"
 
   pushd build/fixtures/spring-petclinic >/dev/null
-  ./mvnw ${BATS_VERSION+--quiet} -DskipTests -Dcheckstyle.skip=true -Dspring-javaformat.skip=true \
+  ./mvnw ${MAVEN_PROFILE} ${BATS_VERSION+--quiet} -DskipTests -Dcheckstyle.skip=true -Dspring-javaformat.skip=true \
     -Dspring-boot.run.agents=$AGENT_JAR -Dspring-boot.run.jvmArguments="-Dappmap.config.file=$WD/test/petclinic/appmap.yml $jvmargs" \
     spring-boot:run \
     &>$LOG  3>&- &

--- a/agent/test/petclinic/jetty.bats
+++ b/agent/test/petclinic/jetty.bats
@@ -1,0 +1,22 @@
+load '../../build/bats/bats-support/load'
+load '../../build/bats/bats-assert/load'
+load '../helper'
+
+load '../petclinic-shared/shared-setup.bash'
+load '../petclinic-shared/static-resources.bash'
+
+setup_file() {
+  export FIXTURE_DIR="build/fixtures/spring-petclinic"
+  _shared_setup
+
+  export MAVEN_PROFILE=-Pjetty
+  start_petclinic >&3
+}
+
+teardown_file() {
+  stop_ws
+}
+
+@test "requests for non-static resources are recorded by default" {
+  _test_requests_for_nonstatic_resources_are_recorded_by_default
+}

--- a/agent/test/petclinic/petclinic-tests.bats
+++ b/agent/test/petclinic/petclinic-tests.bats
@@ -33,7 +33,7 @@ run_petclinic_test() {
 
   cp "../../../test/petclinic/${cfg}" ./appmap.yml
 
-  run ./mvnw ${BATS_VERSION+-q} \
+  run ./mvnw -Ptomcat ${BATS_VERSION+-q} \
     $MAVEN_TEST_PROPS \
     -DargLine="@{argLine} ${JAVA_OUTPUT_OPTIONS} -javaagent:${AGENT_JAR} " \
     clean test -Dtest="${test_name}"
@@ -68,7 +68,7 @@ run_petclinic_test() {
 }
 
 @test "test_status set for successful test" {
-  run ./mvnw \
+  run ./mvnw -Ptomcat \
     $MAVEN_TEST_PROPS \
     -DargLine="@{argLine} -javaagent:${AGENT_JAR} -Dappmap.config.file=../../../test/petclinic/appmap.yml" \
     clean test -Dtest="JUnit5Tests#testItPasses"

--- a/pomupdater/src/main/java/com/appland/appmap/util/PomUpdater.java
+++ b/pomupdater/src/main/java/com/appland/appmap/util/PomUpdater.java
@@ -2,24 +2,25 @@ package com.appland.appmap.util;
 
 import java.io.FileReader;
 import java.io.FileWriter;
+import java.util.Arrays;
 
+import org.apache.maven.model.Activation;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Exclusion;
 import org.apache.maven.model.Model;
+import org.apache.maven.model.Profile;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 
 public class PomUpdater {
   public static void main(String[] argv) {
-    // Define the path to the pom.xml file
     String pomFilePath = argv[0];
-    String annotationJar = argv[1];
+    String annotationJarPath = argv[1];
 
-    // Initialize MavenXpp3Reader and MavenXpp3Writer
     MavenXpp3Reader reader = new MavenXpp3Reader();
     MavenXpp3Writer writer = new MavenXpp3Writer();
 
     try {
-      // Read the existing pom.xml
       Model model;
       try (FileReader fileReader = new FileReader(pomFilePath)) {
         model = reader.read(fileReader);
@@ -34,19 +35,12 @@ public class PomUpdater {
         System.exit(0);
       }
 
-      System.err.println("PomUpdater: adding annotation dependency to " + argv[0]);
+      System.err.println("PomUpdater: updating " + argv[0]);
 
-      Dependency newDependency = new Dependency();
-      newDependency.setGroupId("com.appland");
-      newDependency.setArtifactId("annotation");
-      newDependency.setVersion("LATEST");
-      newDependency.setScope("system");
-      newDependency.setSystemPath(annotationJar);
+      addAnnotationJar(annotationJarPath, model);
 
-      // Add the new dependency to the model
-      model.addDependency(newDependency);
+      addProfiles(model);
 
-      // Write the modified model back to the pom.xml
       try (FileWriter fileWriter = new FileWriter(pomFilePath)) {
         writer.write(fileWriter, model);
       }
@@ -55,5 +49,53 @@ public class PomUpdater {
       e.printStackTrace();
     }
     System.exit(1);
+  }
+
+  private static void addProfiles(Model model) {
+    // Add profiles to allow the choice of embedded servlet container (Tomcat or Jetty) at runtime.
+    // Note that spring-boot-starter-web embeds spring-boot-start-tomcat and will always use it if
+    // present, so it must be explicictly excluded to allow the use of Jetty.
+
+    Exclusion tomcatExclusion = new Exclusion();
+    tomcatExclusion.setGroupId("org.springframework.boot");
+    tomcatExclusion.setArtifactId("spring-boot-starter-tomcat");
+
+    model.getDependencies().stream()
+        .filter(d -> d.getArtifactId().equals("spring-boot-starter-web")).findFirst()
+        .ifPresent(d -> d.addExclusion(tomcatExclusion));
+
+    Dependency tomcatDependency = new Dependency();
+    tomcatDependency.setGroupId("org.springframework.boot");
+    tomcatDependency.setArtifactId("spring-boot-starter-tomcat");
+
+    Dependency jettyDependency = new Dependency();
+    jettyDependency.setGroupId("org.springframework.boot");
+    jettyDependency.setArtifactId("spring-boot-starter-jetty");
+
+    Profile tomcatProfile = new Profile();
+    tomcatProfile.setId("tomcat");
+    Activation activation = new Activation();
+    activation.setActiveByDefault(true);
+    tomcatProfile.setActivation(activation);
+    tomcatProfile.setDependencies(Arrays.asList(tomcatDependency));
+
+    Profile jettyProfile = new Profile();
+    jettyProfile.setId("jetty");
+    jettyProfile.setDependencies(Arrays.asList(jettyDependency));
+
+    model.addProfile(tomcatProfile);
+    model.addProfile(jettyProfile);
+  }
+
+  private static void addAnnotationJar(String annotationJar, Model model) {
+    Dependency newDependency = new Dependency();
+    newDependency.setGroupId("com.appland");
+    newDependency.setArtifactId("annotation");
+    newDependency.setVersion("LATEST");
+    newDependency.setScope("system");
+    newDependency.setSystemPath(annotationJar);
+
+    // Add the new dependency to the model
+    model.addDependency(newDependency);
   }
 }


### PR DESCRIPTION
When instrumenting a Jetty server, only add a Spark handler if the app is really a Spark app. A mistake in the code meant that it added the handler whenever running in a Jetty server. This would cause request recording to fail (and maybe cause other problems, as well).

Fixes #265 .