### PR TITLE
fix: resolve output directory relative to config

### DIFF
--- a/agent/src/main/java/com/appland/appmap/config/AppMapConfig.java
+++ b/agent/src/main/java/com/appland/appmap/config/AppMapConfig.java
@@ -295,7 +295,7 @@ public class AppMapConfig {
       System.exit(1);
     }
 
-    String outputDirectory = System.getProperty(APPMAP_OUTPUT_DIRECTORY_KEY);
+    String outputDirectory = Properties.resolveProperty(APPMAP_OUTPUT_DIRECTORY_KEY, (String)null);
     if (outputDirectory  == null) {
       if (singleton.appmapDir == null) {
         singleton.appmapDir = findDefaultOutputDirectory(fs).toString();

--- a/agent/src/main/java/com/appland/appmap/config/AppMapConfig.java
+++ b/agent/src/main/java/com/appland/appmap/config/AppMapConfig.java
@@ -59,9 +59,24 @@ public class AppMapConfig {
     return org.tinylog.Logger.tag(tag);
   }
 
+  /**
+   * Search for the config file for the current application.
+   *
+   * First, check to see if the specified config file exists. If it does, return it. If it does not,
+   * and mustExist is true, throw a FileNotFoundException.
+   *
+   * If it does not, scan up the directory tree. If a file named appmap.yml is found, return it.
+   * Otherwise, throw a FileNotFoundException.
+   *
+   * @param configFile the starting config file path
+   * @param mustExist if true, throw a FileNotFoundExcpetion if configFile does not exist
+   * @return the absolute path to the discovered config file
+   * @throws FileNotFoundException if mustExist is true and configFile does not exist, or configFile
+   *         does not exist, and no appmap.yml is found in any of the parent directories
+   */
   private static Path findConfig(Path configFile, boolean mustExist) throws FileNotFoundException {
     if (Files.exists(configFile)) {
-      return configFile;
+      return configFile.toAbsolutePath();
     }
 
     if (mustExist) {
@@ -92,10 +107,10 @@ public class AppMapConfig {
 
   /**
    * Populate the configuration from a file.
-   * 
+   *
    * @param configFile The file to be loaded
-   * @param mustExist  When true, the config must already exist; when false, it
-   *                   will be created if it doesn't exist.
+   * @param mustExist When true, the config must already exist; when false, it will be created if it
+   *        doesn't exist.
    *
    * @return The AppMapConfig singleton
    */
@@ -104,10 +119,10 @@ public class AppMapConfig {
 
     try {
       configFile = AppMapConfig.findConfig(configFile, mustExist);
-      logger.debug("using config file -> {}", configFile.toAbsolutePath());
+      logger.debug("using config file -> {}", configFile);
       inputStream = Files.newInputStream(configFile);
     } catch (IOException e) {
-      Path expectedConfig = configFile.toAbsolutePath();
+      Path expectedConfig = configFile;
       logger.error("error: file not found -> {}",
           expectedConfig);
       return null;
@@ -311,7 +326,8 @@ public class AppMapConfig {
         singleton.appmapDir = outputDirectory;
       }
     }
-    Properties.OutputDirectory = fs.getPath(singleton.appmapDir);
+    Properties.OutputDirectory = singleton.configFile.getParent().resolve(singleton.appmapDir);
+
   }
 
   private static Path findDefaultOutputDirectory(FileSystem fs) {

--- a/agent/src/main/java/com/appland/appmap/config/Properties.java
+++ b/agent/src/main/java/com/appland/appmap/config/Properties.java
@@ -41,19 +41,6 @@ public class Properties {
 
 
   static Path OutputDirectory;
-  private static String resolveProperty(String propName, String defaultValue) {
-    String value = defaultValue;
-    try {
-      final String propValue = System.getProperty(propName);
-      if (propValue != null) {
-        value = propValue;
-      }
-    } catch (Exception e) {
-      Logger.printf("failed to resolve %s, falling back to default\n", propName);
-      Logger.println(e);
-    }
-    return value;
-  }
 
   public static Path getOutputDirectory() {
     if (OutputDirectory == null) {
@@ -63,14 +50,19 @@ public class Properties {
     return OutputDirectory;
   }
 
-  private static Boolean resolveProperty(String propName, Boolean defaultValue) {
+  static Boolean resolveProperty(String propName, Boolean defaultValue) {
     return resolveProperty(propName, Boolean::valueOf, defaultValue);
   }
 
-  private static Integer resolveProperty(String propName, Integer defaultValue) {
+  static Integer resolveProperty(String propName, Integer defaultValue) {
     return resolveProperty(propName, Integer::valueOf, defaultValue);
   }
-  private static <T> T resolveProperty(String propName,
+
+  static String resolveProperty(String propName, String defaultValue) {
+    return resolveProperty(propName, Object::toString, defaultValue);
+  }
+
+  static <T> T resolveProperty(String propName,
                                        Function<String, T> resolvingFunc,
                                        T defaultValue) {
     T value = defaultValue;
@@ -91,7 +83,7 @@ public class Properties {
     return value;
   }
 
-  private static String[] resolveProperty(String propName, String[] defaultValue) {
+  static String[] resolveProperty(String propName, String[] defaultValue) {
     String[] value = defaultValue;
     try {
       final String propValue = System.getProperty(propName);

--- a/agent/src/test/java/com/appland/appmap/config/AppMapConfigTest.java
+++ b/agent/src/test/java/com/appland/appmap/config/AppMapConfigTest.java
@@ -63,8 +63,24 @@ public class AppMapConfigTest {
         assertTrue(actualErr.contains("file not found"));
     }
 
-    // If a non-existent config file in a subdirectory is specified, the
-    // config file in the current directory should be used.
+    /**
+     * Ensure that a relative path to an existing candidate config gets resolved to an absolute
+     * path.
+     */
+    @Test
+    public void resolvesRelative() {
+      System.err.println(System.getProperty("user.dir"));
+      Path f = Paths.get("appmap.yml");
+      AppMapConfig.load(f, false);
+      Path expected = Paths.get("appmap.yml").toAbsolutePath();
+      assertTrue(Files.exists(expected)); // sanity check
+      assertEquals(expected, AppMapConfig.get().configFile);
+    }
+
+    /**
+     * Check that if a non-existent config file in a subdirectory is specified, the config file in a
+     * parent directory will be used. Also checks that the resulting config file path is absolute.
+     */
     @Test
     public void loadParent() {
         System.err.println(System.getProperty("user.dir"));

--- a/agent/test/access/access.bats
+++ b/agent/test/access/access.bats
@@ -6,7 +6,7 @@ load '../helper'
 
 sep="$JAVA_PATH_SEPARATOR"
 AGENT_JAR="$(find_agent_jar)"
-wd="$(git rev-parse --show-toplevel)"/agent
+wd=$(getcwd)
 test_cp="${wd}/test/access${sep}${wd}/build/classes/java/test"
 java_cmd="java -javaagent:'${AGENT_JAR}' -cp '${test_cp}'"
 

--- a/agent/test/httpcore/httpcore.bats
+++ b/agent/test/httpcore/httpcore.bats
@@ -12,7 +12,7 @@ load '../helper'
 setup_file() {
 mkdir -p build/log
 
-export LOG=$PWD/build/log/httpcore.log
+export LOG="$(getcwd)/build/log/httpcore.log"
 export SERVER_PORT=9090
 export WS_URL=${WS_URL:-http://localhost:9090}
   cd test/httpcore

--- a/agent/test/petclinic/petclinic-tests.bats
+++ b/agent/test/petclinic/petclinic-tests.bats
@@ -68,9 +68,11 @@ run_petclinic_test() {
 }
 
 @test "test_status set for successful test" {
+  local cfg="../../../test/petclinic/appmap.yml"
+  local out="$(getcwd)/tmp/appmap"
   run ./mvnw -Ptomcat \
     $MAVEN_TEST_PROPS \
-    -DargLine="@{argLine} -javaagent:${AGENT_JAR} -Dappmap.config.file=../../../test/petclinic/appmap.yml" \
+    -DargLine="@{argLine} -javaagent:${AGENT_JAR} -Dappmap.config.file=${cfg} -Dappmap.output.directory=${out}" \
     clean test -Dtest="JUnit5Tests#testItPasses"
   assert_success
 

--- a/agent/test/scala/scala.bats
+++ b/agent/test/scala/scala.bats
@@ -21,18 +21,20 @@ init_example() (
 
 setup_file() {
   export AGENT_JAR="$(find_agent_jar)"
-
+  export FIXTURE_DIR="play-samples/play-scala-rest-api-example"
   cd test/scala
   _configure_logging
 
-  if [[ ! -d play-samples/play-scala-rest-api-example ]]; then
+  if [[ ! -d "${FIXTURE_DIR}" ]]; then
     init_example
   fi
 }
 
 setup() {
-  cd play-samples/play-scala-rest-api-example
-  rm -rf tmp/appmap
+  cd "${FIXTURE_DIR}"
+  export APPMAP_OUTPUT_DIRECTORY="$(getcwd)/tmp/appmap"
+
+  rm -rf "${APPMAP_OUTPUT_DIRECTORY}"
 }
 
 @test "it works" {
@@ -44,7 +46,8 @@ setup() {
 
   # sbt run with the agent generates two AppMaps. Examine the second (newer) one. Get the lengths of
   # the events and classMap arrays, make sure they're not empty
-  local newest="tmp/appmap/java/$(ls -t tmp/appmap/java | head -1)"
+  local out="${APPMAP_OUTPUT_DIRECTORY}/java"
+  local newest="${out}/$(ls -t "${out}" | head -1)"
   local lengths=( $(jq '(.events | length),(.classMap | length)' $newest) )
   assert [ ${lengths[0]} -gt 0 ]
   assert [ ${lengths[1]} -gt 0 ]


### PR DESCRIPTION
The `appmap_dir` specified in a config file should be resolved relative to the location of the config file.

For example, if appmap.yml is in the root of project, contains `appmap_dir: tmp/appmap`, and is discovered for tests in a submodule run by maven, the AppMaps will be in `$project_root/tmp/appmap`. Prior to these changes, the recordings were placed in `$project_root/$submodule_dir/tmp/appmap`.

Fixes #271 .