### PR TITLE
fix: fix NPE running init when no appmap.yml found

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,9 @@ jobs:
                   distribution: temurin
                   java-version: ${{ matrix.java }}
 
-            - name: Install Bash on macOS
+            - name: Install extras on macOS
               if: runner.os == 'macOS'
-              run: brew install bash
+              run: brew install bash sbt
 
             - name: Run Tests
               shell: bash

--- a/agent/src/main/java/com/appland/appmap/config/AppMapConfig.java
+++ b/agent/src/main/java/com/appland/appmap/config/AppMapConfig.java
@@ -97,7 +97,7 @@ public class AppMapConfig {
       Files.createDirectories(projectDirectory);
       Files.write(configFile, getDefault(projectDirectory.toString()).getBytes());
 
-      return configFile;
+      return configFile.toAbsolutePath();
     } catch (IOException e) {
       logger.error(e, "Failed to create default config");
     }

--- a/agent/test/agent_cli/agent_cli.bats
+++ b/agent/test/agent_cli/agent_cli.bats
@@ -7,11 +7,16 @@ load '../helper'
 setup_file() {
   export AGENT_JAR="$(find_agent_jar)"
 
-  rm -rf test/agent_cli/spring-petclinic
-  tar -C build/fixtures -c -f - ./spring-petclinic | tar -x -f - -C test/agent_cli
-  cp -v test/petclinic/appmap.yml test/agent_cli/spring-petclinic/.
+  TEST_DIR="$BATS_FILE_TMPDIR/agent_cli"
+  mkdir -p "$TEST_DIR"
+  rm -rf "$TEST_DIR"/spring-petclinic
 
-  cd test/agent_cli
+  tar -C build/fixtures -c -f - ./spring-petclinic | tar -x -f - -C "$TEST_DIR"
+  cp -v test/petclinic/appmap.yml "$TEST_DIR"/spring-petclinic/.
+
+  tar -c -f - -C test/agent_cli ./sampleproj | tar -x -f - -C "$TEST_DIR"
+
+  cd "$TEST_DIR"
   _configure_logging
 
 }


### PR DESCRIPTION
If there is no `appmap.yml` anywhere in the current directory tree, the `init` subcommand will fail with a NullPointerException. These changes make sure that doesn't happen.

Fixes #280 .