### PR TITLE
fix: detect packages in multi-project repositories

### DIFF
--- a/agent/src/test/java/com/appland/appmap/config/AppMapConfigTest.java
+++ b/agent/src/test/java/com/appland/appmap/config/AppMapConfigTest.java
@@ -37,7 +37,7 @@ public class AppMapConfigTest {
     public void createDefault() throws IOException {
         // Just verify that the file gets created when it should. The contents
         // get verified elsewhere.
-        Path configFile = Paths.get(System.getProperty("java.io.tmpdir"), "appmap.yml");
+        Path configFile = tmpdir.resolve("appmap.yml");
         Files.deleteIfExists(configFile);
         AppMapConfig.load(configFile, false);
         assertTrue(Files.exists(configFile));
@@ -55,7 +55,7 @@ public class AppMapConfigTest {
 
     @Test
     public void requiresExisting() throws Exception {
-        Path configFile = Paths.get(System.getProperty("java.io.tmpdir"), "appmap.yml");
+        Path configFile = tmpdir.resolve("appmap.yml");
         Files.deleteIfExists(configFile);
 
         String actualErr = tapSystemErr(() -> AppMapConfig.load(configFile, true));

--- a/agent/test/agent_cli/agent_cli.bats
+++ b/agent/test/agent_cli/agent_cli.bats
@@ -29,6 +29,8 @@ setup_file() {
   assert_success
   assert_json_contains '.configuration.contents' 'path: pkg1'
   assert_json_contains '.configuration.contents' 'path: pkg2'
+  assert_json_contains '.configuration.contents' 'path: com.example.subprojpkg1'
+  assert_json_contains '.configuration.contents' 'path: com.example.subprojpkg2'
 }
 
 @test "appmap agent init empty project" {

--- a/agent/test/agent_cli/sampleproj/subproj/p1/src/main/java/com/example/subprojpkg1/Class1.java
+++ b/agent/test/agent_cli/sampleproj/subproj/p1/src/main/java/com/example/subprojpkg1/Class1.java
@@ -1,0 +1,1 @@
+// intentionally blank

--- a/agent/test/agent_cli/sampleproj/subproj/p2/src/main/java/com/example/subprojpkg2/Class2.java
+++ b/agent/test/agent_cli/sampleproj/subproj/p2/src/main/java/com/example/subprojpkg2/Class2.java
@@ -1,0 +1,1 @@
+// intentionally blank

--- a/agent/test/intellij/.gitignore
+++ b/agent/test/intellij/.gitignore
@@ -1,0 +1,1 @@
+appmap-intellij-plugin


### PR DESCRIPTION
Fixes #283.

This PR addresses the issue of failure to autodetect package names in some multi-project repositories. Specifically, the Java AppMap agent was unable to auto-detect packages in the multi-project structure of the [Retrofit](https://github.com/square/retrofit) repository. The agent only looked for `src/main/java` directories, which led to an `appmap.yml` configuration file with no detected packages, as shown below:

```yaml
# This is the AppMap configuration file.
# For full documentation of this file for Java programs, see:
# https://appmap.io/docs/reference/appmap-java.html#configuration
name: retrofit
packages: []
# appmap-java init looks for source packages in src/main/java.
# This folder was not found in your project, so no packages were auto-detected.
# You can add your source packages by replacing the line above with lines like this:
# packages:
# - path: com.mycorp.pkg
# - path: org.otherstuff.pkg
```

The repository is structured with multiple subprojects, each containing their own `src/main/java` directories:

### Changes Made
1. **AppMapConfig.java**: Updated `AppMapConfig.java` to traverse the root directory and collect packages from all relevant `src/main/java` directories across subprojects.
   - Introduced a method `collectPackages` to encapsulate the logic for collecting Java packages.
   - Modified the main initialization logic to traverse the root directory and look for `src/main/java` subdirectories.
   - Ensured the autodetection mechanism now works for projects with nested subprojects.
   
2. **agent_cli.bats**: Updated the test for the CLI agent initialization to verify the detection of packages within subprojects.
   - Added assertions to check for the presence of subproject package paths in CLI output.

3. **Test Project Structure**: Added a sample subproject structure to the test project for verifying the updated behavior.