### PR TITLE
feat: Show basic information messages

### DIFF
--- a/agent/src/main/java/com/appland/appmap/Agent.java
+++ b/agent/src/main/java/com/appland/appmap/Agent.java
@@ -17,6 +17,7 @@ import java.util.Enumeration;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
+import com.appland.appmap.util.Logger;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.tinylog.TaggedLogger;
@@ -66,8 +67,10 @@ public class Agent {
           "To disable the automatic creation of this log file, set the system property {} to 'true'",
           Properties.DISABLE_LOG_FILE_KEY);
     }
+    String implementationVersion = Agent.class.getPackage().getImplementationVersion();
+    Logger.printUserMessage("AppMap agent version %s starting\n", implementationVersion);
     logger.info("Agent version {}, current time mills: {}",
-        Agent.class.getPackage().getImplementationVersion(), start);
+            implementationVersion, start);
     logger.info("config: {}", AppMapConfig.get());
     logger.info("System properties: {}", System.getProperties());
     logger.debug(new Exception(), "whereAmI");

--- a/agent/src/main/java/com/appland/appmap/config/Properties.java
+++ b/agent/src/main/java/com/appland/appmap/config/Properties.java
@@ -9,6 +9,9 @@ import com.appland.appmap.util.Logger;
 public class Properties {
   public static final String APPMAP_OUTPUT_DIRECTORY_KEY = "appmap.output.directory";
   public static final String DISABLE_LOG_FILE_KEY = "appmap.disableLogFile";
+
+  public static final Boolean Silent = resolveProperty("appmap.silent", false);
+
   public static final Boolean DisableLogFile = resolveProperty(DISABLE_LOG_FILE_KEY, true);
   public static final Boolean Debug = resolveProperty("appmap.debug", false);
   public static final Boolean DebugHooks = Debug || (System.getProperty("appmap.debug.hooks") != null);

--- a/agent/src/main/java/com/appland/appmap/record/Recording.java
+++ b/agent/src/main/java/com/appland/appmap/record/Recording.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+import com.appland.appmap.util.Logger;
 import org.tinylog.TaggedLogger;
 
 import com.appland.appmap.config.AppMapConfig;
@@ -94,6 +95,7 @@ public class Recording {
             throw new RuntimeException(String.join(", ", errors));
         }
 
+        Logger.printUserMessage("AppMap recording saved to %s\n", targetPath.toAbsolutePath());
         return targetPath;
     }
 

--- a/agent/src/main/java/com/appland/appmap/util/Logger.java
+++ b/agent/src/main/java/com/appland/appmap/util/Logger.java
@@ -1,6 +1,7 @@
 package com.appland.appmap.util;
 
 import com.appland.appmap.config.AppMapConfig;
+import com.appland.appmap.config.Properties;
 
 public class Logger {
   private static final org.tinylog.TaggedLogger logger = AppMapConfig.getLogger(null);
@@ -23,6 +24,17 @@ public class Logger {
 
   public static void error(Throwable t) {
     println(t);
+  }
+
+  /**
+   * Print a message on stderr unless the silent flag is set.
+   * @param format
+   * @param args
+   */
+  public static void printUserMessage(String format, Object... args) {
+    if (!Properties.Silent) {
+      System.err.printf(format, args);
+    }
   }
 
 }

--- a/agent/test/classloading/classloading.bats
+++ b/agent/test/classloading/classloading.bats
@@ -17,7 +17,7 @@ setup_file() {
 }
 
 @test "Proxy" {
-  run \
+  run --separate-stderr \
     ./gradlew ${BATS_VERSION+-q} -PappmapJar="$AGENT_JAR" run --args "TestProxy"
   assert_success
   assert_json_eq ".events[0].defined_class" "com.appland.appmap.test.fixture.helloworld.HelloWorld"

--- a/agent/test/helper.bash
+++ b/agent/test/helper.bash
@@ -31,6 +31,7 @@ _tests_helper() {
   if type -t bats_load_library &>/dev/null; then
     bats_load_library bats-support
     bats_load_library bats-assert
+    bats_require_minimum_version 1.5.0
   fi
 }
 

--- a/agent/test/http_client/httpclient/httpclient.bats
+++ b/agent/test/http_client/httpclient/httpclient.bats
@@ -9,7 +9,7 @@ setup_file() {
 }
 
 @test "request without query" {
-  run ./gradlew -q -PmainClass=httpclient.HttpClientTest run ${DEBUG} --args "${WS_URL}/vets"
+  run --separate-stderr ./gradlew -q -PmainClass=httpclient.HttpClientTest run ${DEBUG} --args "${WS_URL}/vets"
 
   assert_json_eq '.events[1].http_client_request.request_method' "GET"
   assert_json_eq '.events[1].http_client_request.url' "${WS_URL}/vets"
@@ -20,7 +20,7 @@ setup_file() {
 }
 
 @test "request with query" {
-  run ./gradlew -q -PmainClass=httpclient.HttpClientTest run ${DEBUG} --args "${WS_URL}/owners?lastName=davis"
+  run --separate-stderr ./gradlew -q -PmainClass=httpclient.HttpClientTest run ${DEBUG} --args "${WS_URL}/owners?lastName=davis"
 
   assert_json_eq '.events[1].http_client_request.url' "${WS_URL}/owners"
   assert_json_eq '.events[1].message | length' 1
@@ -30,14 +30,14 @@ setup_file() {
 }
 
 @test "request without Content-Type" {
-  run ./gradlew -q -PmainClass=httpclient.HttpClientTest run ${DEBUG} --args "${WS_URL}/no-content"
+  run --separate-stderr ./gradlew -q -PmainClass=httpclient.HttpClientTest run ${DEBUG} --args "${WS_URL}/no-content"
 
   assert_json_eq '.events[1].http_client_request.url' "${WS_URL}/no-content"
   assert_json_eq '.events[2].http_client_response.status' "200"
 }
 
 @test "request with HttpHost" {
-  run ./gradlew -q -PmainClass=httpclient.HttpHostTest run ${DEBUG} --args "${WS_HOST} ${WS_PORT} /owners?lastName=davis"
+  run --separate-stderr ./gradlew -q -PmainClass=httpclient.HttpHostTest run ${DEBUG} --args "${WS_HOST} ${WS_PORT} /owners?lastName=davis"
 
   assert_json_eq '.events[1].http_client_request.url' "${WS_URL}/owners"
   assert_json_eq '.events[1].message | length' 1

--- a/agent/test/petclinic/petclinic-tests.bats
+++ b/agent/test/petclinic/petclinic-tests.bats
@@ -96,7 +96,7 @@ run_petclinic_test() {
 
 @test "NoAppMap on method disables test recording" {
   run_petclinic_test "JUnit5Tests#testAnnotatedMethodNotRecorded"
-  assert_output 'passing annotated test, not recorded'
+  assert_output --partial 'passing annotated test, not recorded'
 
   run test \! -f ./tmp/appmap/junit/org_springframework_samples_petclinic_JUnit5Tests_testAnnotatedMethodNotRecorded.appmap.json
   assert_success
@@ -104,7 +104,7 @@ run_petclinic_test() {
 
 @test "NoAppMap on class disables test recording" {
   run_petclinic_test "JUnit5Tests\$TestClass#testAnnotatedClassNotRecorded"
-  assert_output "passing annotated class, not recorded"
+  assert_output --partial "passing annotated class, not recorded"
 
   run test \! -f ./tmp/appmap/junit/org_springframework_samples_petclinic_JUnit5Tests_testAnnotatedMethodNotRecorded.appmap.json
   assert_success


### PR DESCRIPTION
Print basic informational messages on stderr (when starting and when appmap is written). This can be disabled with `appmap.silent` property.

### Enhancements to Logging and Configuration:

* [`agent/src/main/java/com/appland/appmap/Agent.java`](diffhunk://#diff-f21749602122689f6874d2a0c1811f06964b6cb87f516e580bd3d75306e1f75cR70-R73): Added logging of the AppMap agent version at startup and improved existing log messages to use the new `Logger.printUserMessage` method.
* [`agent/src/main/java/com/appland/appmap/config/Properties.java`](diffhunk://#diff-5110ee7052604c817d7583d1f4e64819ddd92f35c5306b498c1c95d14c7f4e45R12-R14): Introduced a new property `Silent` to control whether user messages should be printed to stderr.
* [`agent/src/main/java/com/appland/appmap/record/Recording.java`](diffhunk://#diff-fa7e6768315ced857e457cfa011fdc1c08c59d8489eb400bed1969e5d527b5e3R98): Added a log message to indicate when an AppMap recording is saved, using the new `Logger.printUserMessage` method.

### New Utility Method:

* [`agent/src/main/java/com/appland/appmap/util/Logger.java`](diffhunk://#diff-33a2f64897c48a3ab7195481978819eb171bf1e37e7192c2cb149dfbcbab4cb3R29-R39): Added a new method `printUserMessage` to print messages to stderr unless the silent flag is set. This method is used to provide user-friendly messages during agent operations.

### Import Adjustments:

* `agent/src/main/java/com/appland/appmap/Agent.java` and `agent/src/main/java/com/appland/appmap/record/Recording.java`: Added imports for the new `Logger` utility. [[1]](diffhunk://#diff-f21749602122689f6874d2a0c1811f06964b6cb87f516e580bd3d75306e1f75cR20) [[2]](diffhunk://#diff-fa7e6768315ced857e457cfa011fdc1c08c59d8489eb400bed1969e5d527b5e3R21)