### PR TITLE
ci: Restrict release workflow to master branch builds and fix broken tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,14 +17,14 @@ jobs:
     name: Build and check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v4
@@ -34,7 +34,7 @@ jobs:
         run: ./gradlew shadowJar annotation:jar check integrationTest
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Jars
           path: |
@@ -61,9 +61,9 @@ jobs:
     name: Run test suite with Java ${{ matrix.java }}
     needs: build-and-check
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         name: Set up Java
         with:
           java-version: ${{ matrix.java }}
@@ -83,7 +83,7 @@ jobs:
       - uses: sbt/setup-sbt@v1
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Jars
 
@@ -95,21 +95,21 @@ jobs:
         working-directory: ./agent
         run: bin/test_projects
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         name: Set up Gradle cache
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: gradle
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         name: Set up Maven cache
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: maven
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         name: Set up sbt cache
         with:
           java-version: ${{ matrix.java }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
       - uses: actions/setup-java@v5
         with:
           java-version: "21"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       pull-requests: write
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     workflows: ["Build and test"]
     types:
       - completed
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       dry_run:
@@ -23,7 +25,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     steps:
       - uses: actions/checkout@v5
         with:

--- a/agent/src/test/fixture/shared/src/main/java/org/springframework/samples/petclinic/web/ShowAvailable.java
+++ b/agent/src/test/fixture/shared/src/main/java/org/springframework/samples/petclinic/web/ShowAvailable.java
@@ -1,12 +1,8 @@
 package org.springframework.samples.petclinic.web;
 
-import java.io.IOException;
-
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * ShowAvailable is a simple Spring Controller that simply returns the number
@@ -14,21 +10,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 @RestController
 public class ShowAvailable {
-  private static class Result {
-    private final int available;
-
-    public Result(int available) {
-      this.available = available;
-    }
-
-    public String getAvailable() {
-      return Integer.toString(available);
-    }
-  }
 
   @PostMapping("/showavailable")
-  public String doPost(@RequestBody String body) throws Exception {
-    return new ObjectMapper().writeValueAsString(new Result(body.length()));
+  public String doPost(@RequestBody String body) {
+    return String.format("{\"available\":\"%d\"}", body.length());
   }
 
 }

--- a/agent/test/intellij/intellij.bats
+++ b/agent/test/intellij/intellij.bats
@@ -5,7 +5,7 @@ init_plugin() {
 }
 
 setup_file() {
-  is_java 17 || skip "needs Java 17"
+  is_java 21 || skip "needs Java 21"
   is_java 25 && skip "incompatible with Java 25"
 
   export AGENT_JAR="$(find_agent_jar)"

--- a/agent/test/petclinic/petclinic-tests.bats
+++ b/agent/test/petclinic/petclinic-tests.bats
@@ -40,13 +40,13 @@ run_petclinic_test() {
 @test "hooked functions are ordered correctly" {
   run_petclinic_test
   assert_success
-  run cat ./tmp/appmap/junit/org_springframework_samples_petclinic_${TEST_NAME}_testOwnerDetails.appmap.json
+  run cat ./tmp/appmap/junit/org_springframework_samples_petclinic_${TEST_NAME}_*wnerDetails.appmap.json
   assert_success
 
   # Find the test runner's main thread (the one with testOwnerDetails method).
   # Check to make sure that parent_id of the "return" event matches the id of the "call" event.
   # Note: In Java 21 the main thread is typically thread 1, but in Java 25 it can be thread 3.
-  local main_thread_id=$(jq -r '[.events[] | select(.method_id == "testOwnerDetails")][0].thread_id' ./tmp/appmap/junit/org_springframework_samples_petclinic_${TEST_NAME}_testOwnerDetails.appmap.json)
+  local main_thread_id=$(jq -r '[.events[] | select(.method_id | test("^.*wnerDetails$")?)][0].thread_id' ./tmp/appmap/junit/org_springframework_samples_petclinic_${TEST_NAME}_*wnerDetails.appmap.json)
   assert_json_eq ".events | map(select(.thread_id == ${main_thread_id})) | ((.[0].event == \"call\" and .[1].event == \"return\") and (.[1].parent_id == .[0].id))" "true"
 }
 
@@ -62,9 +62,9 @@ run_petclinic_test() {
 @test "log methods are labeled" {
   run_petclinic_test "${TEST_NAME}" appmap-labels.yml
   assert_success
-  run cat ./tmp/appmap/junit/org_springframework_samples_petclinic_${TEST_NAME}_testOwnerDetails.appmap.json
+  run cat ./tmp/appmap/junit/org_springframework_samples_petclinic_${TEST_NAME}_*wnerDetails.appmap.json
 
-  assert_json_eq '.classMap[0] | recurse(.children[]?) | select(.type? == "function" and .name? == "info").labels[0]' 'log'
+  assert_json_eq 'first(.classMap[0] | recurse(.children[]?) | select(.type? == "function" and (.name? | IN("info", "debug")))).labels[0]' 'log'
 }
 
 @test "test_status set for successful test" {


### PR DESCRIPTION
Previously, the release workflow triggered on every "Build and test" run regardless of branch. Although a job-level condition prevented actual releases, the workflow still ran and prompted admin approval due to its access to signing and publishing secrets.

Added a branches filter to the workflow_run trigger so the workflow is never queued for feature branch builds, and removed the now-redundant head_branch check from the job condition.

In addition, I noticed that release always ran against current master, instead of the revision that actually passed tests; this is fixed now.

Also, I discovered a few issues with our integration tests that failed due to upstream project changes. These have now been fixed.