### PR TITLE
fix: don't log full JVM system properties at debug level

### DIFF
--- a/agent/src/main/java/com/appland/appmap/Agent.java
+++ b/agent/src/main/java/com/appland/appmap/Agent.java
@@ -43,6 +43,18 @@ public class Agent {
   public static final TaggedLogger logger = AppMapConfig.getLogger(null);
 
   /**
+   * Returns only the {@code appmap.*} system properties from {@code props}, so that arbitrary
+   * properties (e.g. secrets passed via {@code -Dpassword=...}) never end up in the log file.
+   */
+  static java.util.Properties filterAppMapProperties(java.util.Properties props) {
+    java.util.Properties appmapProperties = new java.util.Properties();
+    props.stringPropertyNames().stream()
+        .filter(name -> name.startsWith("appmap."))
+        .forEach(name -> appmapProperties.setProperty(name, props.getProperty(name)));
+    return appmapProperties;
+  }
+
+  /**
    * premain is the entry point for the AppMap Java agent.
    *
    * @param agentArgs agent options
@@ -75,13 +87,7 @@ public class Agent {
     // Only log AppMap's own system properties, never the full set: arbitrary
     // properties (e.g. -Dpassword=... on the command line) must never end up
     // in the log file.
-    logger.debug("System properties: {}", () -> {
-      java.util.Properties appmapProperties = new java.util.Properties();
-      System.getProperties().stringPropertyNames().stream()
-          .filter(name -> name.startsWith("appmap."))
-          .forEach(name -> appmapProperties.setProperty(name, System.getProperty(name)));
-      return appmapProperties;
-    });
+    logger.debug("System properties: {}", () -> filterAppMapProperties(System.getProperties()));
 
     if (Agent.class.getClassLoader() == null) {
       logger.warn("AppMap agent is running on the bootstrap classpath. This is not a recommended configuration and should only be used for troubleshooting. Git integration will be disabled.");

--- a/agent/src/main/java/com/appland/appmap/Agent.java
+++ b/agent/src/main/java/com/appland/appmap/Agent.java
@@ -87,7 +87,7 @@ public class Agent {
     // Only log AppMap's own system properties, never the full set: arbitrary
     // properties (e.g. -Dpassword=... on the command line) must never end up
     // in the log file.
-    logger.debug("System properties: {}", () -> filterAppMapProperties(System.getProperties()));
+    logger.debug("AppMap system properties: {}", () -> filterAppMapProperties(System.getProperties()));
 
     if (Agent.class.getClassLoader() == null) {
       logger.warn("AppMap agent is running on the bootstrap classpath. This is not a recommended configuration and should only be used for troubleshooting. Git integration will be disabled.");

--- a/agent/src/main/java/com/appland/appmap/Agent.java
+++ b/agent/src/main/java/com/appland/appmap/Agent.java
@@ -72,7 +72,16 @@ public class Agent {
     logger.info("Agent version {}, current time mills: {}",
             implementationVersion, start);
     logger.info("config: {}", AppMapConfig.get());
-    logger.debug("System properties: {}", System.getProperties());
+    // Only log AppMap's own system properties, never the full set: arbitrary
+    // properties (e.g. -Dpassword=... on the command line) must never end up
+    // in the log file.
+    logger.debug("System properties: {}", () -> {
+      java.util.Properties appmapProperties = new java.util.Properties();
+      System.getProperties().stringPropertyNames().stream()
+          .filter(name -> name.startsWith("appmap."))
+          .forEach(name -> appmapProperties.setProperty(name, System.getProperty(name)));
+      return appmapProperties;
+    });
 
     if (Agent.class.getClassLoader() == null) {
       logger.warn("AppMap agent is running on the bootstrap classpath. This is not a recommended configuration and should only be used for troubleshooting. Git integration will be disabled.");

--- a/agent/src/test/java/com/appland/appmap/AgentTest.java
+++ b/agent/src/test/java/com/appland/appmap/AgentTest.java
@@ -1,0 +1,41 @@
+package com.appland.appmap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+public class AgentTest {
+
+  @Test
+  void filterAppMapPropertiesKeepsOnlyAppMapKeys() {
+    Properties props = new Properties();
+    props.setProperty("appmap.debug", "true");
+    props.setProperty("appmap.output.directory", "/tmp/appmap");
+    props.setProperty("password", "hunter2");
+    props.setProperty("user.home", "/home/user");
+    props.setProperty("javax.net.ssl.trustStorePassword", "secret");
+
+    Properties filtered = Agent.filterAppMapProperties(props);
+
+    assertEquals(2, filtered.size());
+    assertEquals("true", filtered.getProperty("appmap.debug"));
+    assertEquals("/tmp/appmap", filtered.getProperty("appmap.output.directory"));
+    assertFalse(filtered.containsKey("password"));
+    assertFalse(filtered.containsKey("user.home"));
+    assertFalse(filtered.containsKey("javax.net.ssl.trustStorePassword"));
+  }
+
+  @Test
+  void filterAppMapPropertiesReturnsEmptyWhenNoneMatch() {
+    Properties props = new Properties();
+    props.setProperty("password", "hunter2");
+
+    Properties filtered = Agent.filterAppMapProperties(props);
+
+    assertTrue(filtered.isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up from an audit prompted by a security incident in the sibling `appmap-python` agent, where the full process environment was being logged by default (including secrets), and ended up committed to git in an accidentally-generated log file.

appmap-java doesn't have that exact bug — log file creation is already opt-in (`Properties.DisableLogFile` defaults to `true`, a fix the project shipped previously per `CHANGELOG.md`). But the same class of mistake was still present one level down: with debug logging enabled (`-Dappmap.debug=true`) *and* the log file explicitly turned on, `Agent.java` logged the **entire** JVM system properties map via `System.getProperties()`, which can include secrets passed on the command line (e.g. `-Dpassword=...`).

## Changes

- `Agent.java`: extracted the property-filtering logic into a small static method, `Agent.filterAppMapProperties()`, which keeps only `appmap.*` keys instead of dumping every JVM system property.
- `AgentTest.java` (new): unit tests for `filterAppMapProperties()` covering both that `appmap.*` properties pass through and that unrelated properties (including a simulated secret) are excluded.

## Test plan
- [x] Compiled cleanly via `gradle :agent:compileJava` (project's pinned Gradle wrapper version wasn't downloadable in this environment, used a local Gradle install instead)
- [x] `gradle :agent:test --tests "com.appland.appmap.AgentTest"` — both new tests pass
